### PR TITLE
TACODEV-776: generate resource yamls from helmrelease mannifest

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -5,10 +5,9 @@ name: Validate
 # Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
-  pull_request:
+  push:
     branches:
-      - 'main'
-
+      - main
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,19 +21,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Run render.sh
+      - name: Run render-cd.sh
         run: |
           set -xe
-          chmod +x .github/workflows/render.sh
-          .github/workflows/render.sh
-      - name: Trigger jenkins job
-        uses: jabbukka/jenkins-trigger@main
-        with:
-          url: ${{ secrets.JENKINS_URL }}
-          job_name: "deploy-apps"
-          user_name: ${{ secrets.JENKINS_USER }}
-          api_token: ${{ secrets.JENKINS_TOKEN }}
-          wait: "true"
-          timeout: "3600"
-          parameter: "{\"SITE_BRANCH\":\"${{ github.head_ref }}\"}"
+          chmod +x .github/workflows/render-cd.sh
+          .github/workflows/render-cd.sh
 
+      - name: Pushes to the repository for argocd
+        uses: cpina/github-action-push-to-another-repository@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'cd'
+          destination-github-username: 'openinfradev'
+          destination-repository-name: 'decapod-site-cd'
+          user-email: 'taco_support@sk.com'
+          commit-message: See ORIGIN_COMMIT
+          target-branch: main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Validate
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request:
+    branches:
+      - main
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Run render-cd.sh
+        run: |
+          set -xe
+          chmod +x .github/workflows/render-cd.sh
+          .github/workflows/render-cd.sh
+
+      - name: Pushes to the repository for argocd
+        uses: cpina/github-action-push-to-another-repository@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'cd'
+          destination-github-username: 'openinfradev'
+          destination-repository-name: 'decapod-site-cd'
+          user-email: 'taco_support@sk.com'
+          commit-message: See ORIGIN_COMMIT
+          target-branch: temporary_from_pr
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.github/workflows/render-cd.sh
+++ b/.github/workflows/render-cd.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+DECAPOD_BASE_URL=https://github.com/openinfradev/decapod-base-yaml.git
+BRANCH="main"
+CD_FILE_TARGET_URL=https://github.com/openinfradev/decapod-site-cd.git
+CD_BRANCH="main"
+
+pwd
+ls
+
+if [ $# -eq 1 ]; then
+  BRANCH=$1
+fi
+
+site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs' | grep -v 'cd')
+echo "Fetch base with $BRANCH branch/tag........"
+git clone -b $BRANCH $DECAPOD_BASE_URL
+if [ $? -ne 0 ]; then
+  exit $?
+fi
+
+mkdir cd
+
+for i in ${site_list}
+do
+  echo "Starting build manifests for '$i' site"
+
+  for app in `ls $i/`
+  do
+    output="$i/$app/$app-manifest.yaml"
+    cp -r decapod-base-yaml/$app/base $i/
+    echo "Rendering $app-manifest.yaml for $i site"
+    docker run --rm -i -v $(pwd)/$i:/$i --name kustomize-build sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /$i/$app -o /$i/$app/$app-manifest.yaml
+    build_result=$?
+
+    if [ $build_result != 0 ]; then
+      exit $build_result
+    fi
+
+    if [ -f "$output" ]; then
+      echo "[$i, $app] Successfully Generate Helm-Release Files!"
+    else
+      echo "[$i, $app] Failed to render $app-manifest.yaml"
+      rm -rf $i/base decapod-yaml
+      exit 1
+    fi
+
+    docker run --rm -i -v $(pwd)/$i:/$i -v $(pwd)/cd:/cd --name generate siim/helmrelease2yaml:1.0.0 $output cd/$i/$app
+
+    rm -rf $i/base
+  done
+done
+
+rm -rf decapod-base-yaml


### PR DESCRIPTION
추가된 액션은 다음의 두가지 작업을 수행합니다.

### main으로 Pull Request가 생성되면 모든 사이트의 모든 앱에 대해 다음과 같은 작업을 수행합니다.
1. pr의 source  branch 내용을 토대로 decapod rendering을 수행하여 decapod manifest를 만들고 
2. decapod manifest를 chart별로 [kind]_[name].yaml 파일로 분해한 후
3. 이를 https://github.com/openinfradev/decapod-site-cd 로 temporary_from_pr branch로 push
4. 이때 이를 발생시킨 commit의 hash코드가 commit message라 남습니다.

### PR이 main으로 merge될 때 모든 사이트의 모든 앱에 대해 다음과 같은 작업을 수행합니다.
1. pr의 source  branch 내용을 토대로 decapod rendering을 수행하여 decapod manifest를 만들고 
2. decapod manifest를 chart별로 [kind]_[name].yaml 파일로 분해한 후
3. 이를 https://github.com/openinfradev/decapod-site-cd 의 main branch로 push 
4. 이때 이를 발생시킨 commit의 hash코드가 commit message라 남습니다.
