### PR TITLE
fix version of github-action to commit

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -28,7 +28,7 @@ jobs:
           .github/workflows/render-cd.sh
 
       - name: Pushes to the repository for argocd
-        uses: cpina/github-action-push-to-another-repository@master
+        uses: cpina/github-action-push-to-another-repository@v1.3
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
           .github/workflows/render-cd.sh
 
       - name: Pushes to the repository for argocd
-        uses: cpina/github-action-push-to-another-repository@master
+        uses: cpina/github-action-push-to-another-repository@v1.3
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:


### PR DESCRIPTION
git action의 master branch를 main으로 바꾸면서 문제가 발생한 것 같아
현 최신버전인 v1.3으로 고정