### PR TITLE
Fix prometheus alert url

### DIFF
--- a/gate-centos-lb-ceph-online-multinodes/lma/site-values.yaml
+++ b/gate-centos-lb-ceph-online-multinodes/lma/site-values.yaml
@@ -30,9 +30,12 @@ charts:
     
 - name: prometheus-fed-master
   override:
+    alertmanager.service.type: NodePort
+    alertmanager.service.nodePort: 30111
+    alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
     alertmanager.alertmanagerSpec.nodeSelector: $(nodeSelector)
     alertmanager.alertmanagerSpec.retention: 2h
-    alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
+    alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi

--- a/hanu-deploy-apps/lma/site-values.yaml
+++ b/hanu-deploy-apps/lma/site-values.yaml
@@ -32,9 +32,12 @@ charts:
     
 - name: prometheus-fed-master
   override:
+    alertmanager.service.type: NodePort
+    alertmanager.service.nodePort: 30111
+    alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
     alertmanager.alertmanagerSpec.nodeSelector: $(nodeSelector)
     alertmanager.alertmanagerSpec.retention: 2h
-    alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
+    alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi


### PR DESCRIPTION
for hanu-deploy-apps and gate-centos-lb-ceph-online-multinodes
- alertmanager nodePort enabled
- alertmanagerConfigSelector setting
- slack_api_url fix