### PR TITLE
Add registry to kube-state-metrics

### DIFF
--- a/hanu-deploy-apps-offline/lma/image-values.yaml
+++ b/hanu-deploy-apps-offline/lma/image-values.yaml
@@ -81,7 +81,8 @@ charts:
 
 - name: kube-state-metrics
   override:
-    image.repository: $(registry)/bitnami/kube-state-metrics
+    image.registry: $(registry)
+    image.repository: bitnami/kube-state-metrics
     image.tag: 1.9.7-debian-10-r143
 
 - name: prometheus


### PR DESCRIPTION
kube-state-metrics chart use 'registry' value for image

kube-state-metrics chart에서 Image value를 registry, repository, tag로 설정하고 있어서 누락된 registry value를 추가해주었습니다.