### PR TITLE
Delete owner info for local registry

### DIFF
--- a/hanu-deploy-apps-offline/lma/image-values.yaml
+++ b/hanu-deploy-apps-offline/lma/image-values.yaml
@@ -146,7 +146,7 @@ charts:
 
 - name: kubernetes-event-exporter
   override:
-    image.repository: $(registry)/siim/kubernetes-event-exporter
+    image.repository: $(registry)/kubernetes-event-exporter
     image.tag: 0.1.0
     image.PullPolicy: IfNotPresent
 


### PR DESCRIPTION
In the taco archive, the image file is stored using only the name of
the container image, so this PS remove owner info at image value.

현재 taco 아카이브에는 컨테이너 이미지 저장 시 소유자 정보가 없는 순수 이름만 태그하여 저장하기 때문에
image 이름에 소유자 정보가 있는 값을 수정하였습니다.
