### PR TITLE
hanu-deploy-apps-offline: fix service-mesh-* image overrrides

### DIFF
--- a/hanu-deploy-apps-offline/service-mesh/image-values.yaml
+++ b/hanu-deploy-apps-offline/service-mesh/image-values.yaml
@@ -31,8 +31,10 @@ charts:
 
 - name: service-mesh-controlplane
   override: 
-    image.hub: $(registry)/istio-testing
-    image.tag: 1.11-alpha.aa439f6e4772aa52acafa11ac7a5fbdfbb160357
+    IstioOperator.image.hub: $(registry)/istio-testing
+    IstioOperator.image.tag: 1.11-alpha.aa439f6e4772aa52acafa11ac7a5fbdfbb160357
 
 - name: service-mesh-gateway
-  override: {}
+  override:
+    IstioOperator.image.hub: $(registry)/istio-testing
+    IstioOperator.image.tag: 1.11-alpha.aa439f6e4772aa52acafa11ac7a5fbdfbb160357


### PR DESCRIPTION
service-mesh-resource 차트의 이미지 관련 변수 참조가 잘못된 부분을 수정하였습니다.
참고: https://github.com/openinfradev/helm-charts/blob/e0010a44fc1069e3837a649dcfa48c1e903d699a/service-mesh-resource/values.yaml#L22 