### PR TITLE
TACODEV-859: refine reder shells for the use of manual rendering

### DIFF
--- a/.github/workflows/render-cd.sh
+++ b/.github/workflows/render-cd.sh
@@ -2,14 +2,24 @@
 DECAPOD_BASE_URL=https://github.com/openinfradev/decapod-base-yaml.git
 BRANCH="main"
 
-pwd
-ls
-
-if [ $# -eq 1 ]; then
-  BRANCH=$1
-fi
+rm -rf decapod-base-yaml
 
 site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs' | grep -v 'cd')
+
+outputdir="cd"
+if [ $# -eq 1 ]; then
+  BRANCH=$1
+elif [ $# -eq 2 ]; then
+  BRANCH=$1
+  outputdir=$2
+elif [ $# -eq 3 ]; then
+  BRANCH=$1
+  outputdir=$2
+  site_list=$3
+fi
+
+echo "[render-cd] dacapod branch=$BRANCH, output target=$outputdir ,target site(s)=${site_list}\n\n"
+
 echo "Fetch base with $BRANCH branch/tag........"
 git clone -b $BRANCH $DECAPOD_BASE_URL
 if [ $? -ne 0 ]; then
@@ -20,13 +30,13 @@ mkdir cd
 
 for i in ${site_list}
 do
-  echo "Starting build manifests for '$i' site"
+  echo "[render-cd] Starting build manifests for '$i' site"
 
   for app in `ls $i/`
   do
     output="$i/$app/$app-manifest.yaml"
     cp -r decapod-base-yaml/$app/base $i/
-    echo "Rendering $app-manifest.yaml for $i site"
+    echo "[render-cd] Rendering $app-manifest.yaml for $i site"
     docker run --rm -i -v $(pwd)/$i:/$i --name kustomize-build sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /$i/$app -o /$i/$app/$app-manifest.yaml
     build_result=$?
 
@@ -35,15 +45,16 @@ do
     fi
 
     if [ -f "$output" ]; then
-      echo "[$i, $app] Successfully Generate Helm-Release Files!"
-      cat $output
+      echo "[render-cd] [$i, $app] Successfully Generate Helm-Release Files!"
     else
-      echo "[$i, $app] Failed to render $app-manifest.yaml"
+      echo "[render-cd] [$i, $app] Failed to render $app-manifest.yaml"
       rm -rf $i/base decapod-yaml
       exit 1
     fi
 
-    docker run --rm -i -v $(pwd)/$i:/$i -v $(pwd)/cd:/cd --name generate siim/helmrelease2yaml:1.0.0 $output cd/$i/$app
+    # cat $output
+    docker run --rm -i --net=host -v $(pwd)/$i:/$i -v $(pwd)/$outputdir:/cd --name generate siim/helmrelease2yaml:v1.1.0 -m $output -t -o /cd/$i/$app
+    rm $output
 
     rm -rf $i/base
   done

--- a/.github/workflows/render.sh
+++ b/.github/workflows/render.sh
@@ -2,11 +2,14 @@
 DECAPOD_BASE_URL=https://github.com/openinfradev/decapod-base-yaml.git
 BRANCH="main"
 
+site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs')
 if [ $# -eq 1 ]; then
   BRANCH=$1
+elif [ $# -eq 2 ]; then
+  BRANCH=$1
+  site_list=$2
 fi
 
-site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs')
 echo "Fetch base with $BRANCH branch/tag........"
 git clone -b $BRANCH $DECAPOD_BASE_URL
 if [ $? -ne 0 ]; then

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
           days-before-issue-stale: 7
           days-before-pr-stale: 3
           days-before-issue-close: 3
-          days-before-pr-close: 3 
+          days-before-pr-close: 3


### PR DESCRIPTION
다음과 같은 명령으로 사용가능함

github-action에서 사용하고 있는 쉘스크립트 사용 (decapod-site나 이를 folk해서 만드는 개별 사이트에 존재하는 액션임)
파라미터는 0~3개 지정
1: decapod-base-yaml의 브랜치 명, default는 main
2: 생성하고자 하는 디렉토리 default는 cd'
3: redering 하고자하는 사이트,  default는 전체
- 쉘스크립트를 확인하면 알겠지만 default를 선택하면 현재 디렉토리의 모든 디렉토리에 대해 작업하는데 doc부분만 뺀다
- 이미 한번 이상 돌린 경우에는 cd 혹은 지정한 디렉토리가 생겼을 것이고 이에 대해 에러가 발생할 것임 

실행 예) sudo .github/workflows/render-cd.sh main abcd hanu-reference