### PR TITLE
Dev support GitHub directory

### DIFF
--- a/.github/workflows/render.sh
+++ b/.github/workflows/render.sh
@@ -2,11 +2,14 @@
 DECAPOD_BASE_URL=https://github.com/openinfradev/decapod-base-yaml.git
 BRANCH="main"
 
+site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs')
 if [ $# -eq 1 ]; then
   BRANCH=$1
+elif [ $# -eq 2 ]; then
+  BRANCH=$1
+  site_list=$2
 fi
 
-site_list=$(ls -d */ | sed 's/\///g' | grep -v 'docs')
 echo "Fetch base with $BRANCH branch/tag........"
 git clone -b $BRANCH $DECAPOD_BASE_URL
 if [ $? -ne 0 ]; then

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
           days-before-issue-stale: 7
           days-before-pr-stale: 3
           days-before-issue-close: 3
-          days-before-pr-close: 3 
+          days-before-pr-close: 3


### PR DESCRIPTION
내용
현재 사용하는 manifest는 helm repo에 저장된 chart를 기반으로 돌아가도록 되어있다.
개발의 편의성을 위해 github이나 local에 올라간 소스를 기반으로 배포하는 것을 위한 유틸리티가 있다면 좋겠다.

수행내역
spec.chart를 재정의해서 필요한 기능을 수행할수 있도록 제반 유틸리티 수정

    type: helmrepo
    repository: https://prometheus-community.github.io/helm-charts
    name: kube-prometheus-stack
    version: 14.5.0
 또는

    type: git
    repository: git@github.com:helm/charts
    name: charts/stable/prometheus-operator
    version: master 
와 같이 정의 가능하고 type은 생략할 수 있고 기본값 helmrepo로 산정되어 작업됨

type이 git이면 repository는 git 과 같은 의미 name은 path와 같은 의미 version은 ref와 같은 의미로 동작하도록 한다.

산출물
https://github.com/openinfradev/decapod-site/pull/33
https://github.com/openinfradev/decapod-base-yaml/pull/87
https://github.com/openinfradev/kustomize-helm-transformer/pull/30