### PR TITLE
servicemesh refactoring

### DIFF
--- a/gate-centos-lb-ceph-online-multinodes/service-mesh/kustomization.yaml
+++ b/gate-centos-lb-ceph-online-multinodes/service-mesh/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
   - ../base
+    
+transformers:
+  - site-values.yaml

--- a/gate-centos-lb-ceph-online-multinodes/service-mesh/site-values.yaml
+++ b/gate-centos-lb-ceph-online-multinodes/service-mesh/site-values.yaml
@@ -4,7 +4,6 @@ metadata:
   name: site
 
 global:
-  repository: https://VM-NAME-1:8879/
   serviceMeshControlNodeSelector:
     servicemesh: enabled
   serviceMeshIngressNodeSelector:
@@ -24,8 +23,6 @@ global:
 
 charts:
 - name: istio-operator
-  source:
-    repository: $(repository)
   override:
     revision: $(istioRevision)
     hub: docker.io/istio
@@ -36,8 +33,6 @@ charts:
     operator.resources.requests.memory: 128Mi
 
 - name: servicemesh-controlplane
-  source:
-    repository: $(repository)
   override:
     IstioOperator.revision: $(istioRevision)
     IstioOperator.image.hub: docker.io/istio
@@ -56,8 +51,6 @@ charts:
     IstioOperator.components.pilot.k8s.nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-gateway
-  source:
-    repository: $(repository)
   override:
     IstioOperator.revision: $(istioRevision)
     IstioOperator.image.hub: docker.io/istio
@@ -84,14 +77,10 @@ charts:
     IstioOperator.components.egressGateways.k8s.nodeSelector: $(serviceMeshEgressNodeSelector)
 
 - name: jaeger-operator
-  source:
-    repository: $(repository)
   override:
     nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-jaeger-resource
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     logLevel: debug
@@ -119,14 +108,10 @@ charts:
                   number: 16686
 
 - name: kiali-operator
-  source:
-    repository: $(repository)
   override:
     nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-kiali-resource
-  source:
-    repository: $(repository)
   override:
     istioComponentNamespaces.prometheus: lma
     istioNamespace: istio-system
@@ -159,22 +144,16 @@ charts:
                   number: 20001
 
 - name: servicemesh-grafana-dashboard
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
 
 - name: servicemesh-prometheusmonitor
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     istio.interval: "15s"
     jaeger.interval: "15s"
 
 - name: servicemesh-prometheusrule
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     aggregation.interval: "15s"

--- a/hanu-reference-offline/service-mesh/image-values.yaml
+++ b/hanu-reference-offline/service-mesh/image-values.yaml
@@ -8,8 +8,8 @@ global:
 charts:
 - name: istio-operator
   override:
-    hub: $(registry)/istio-testing
-    tag: latest
+    hub: $(registry)/istio
+    tag: 1.10.2
 
 - name: jaeger-operator
   override:
@@ -19,10 +19,31 @@ charts:
 - name: kiali-operator
   override:
     image.repo: $(registry)/kiali/kiali-operator
-    image.tag: v1.30.0
+    image.tag: v1.34.0
 
-- name: service-mesh-controlplane
+- name: servicemesh-controlplane
   override: {}
 
-- name: service-mesh-gateway
+- name: servicemesh-gateway
+  override: {}
+
+- name: jaeger-operator
+  override: {}
+
+- name: servicemesh-jaeger-resource
+  override: {}
+
+- name: kiali-operator
+  override: {}
+
+- name: servicemesh-kiali-resource
+  override: {}
+
+- name: servicemesh-grafana-dashboard
+  override: {}
+
+- name: servicemesh-prometheusmonitor
+  override: {}
+
+- name: servicemesh-prometheusrule
   override: {}

--- a/hanu-reference/service-mesh/kustomization.yaml
+++ b/hanu-reference/service-mesh/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
   - ../base
+    
+transformers:
+  - site-values.yaml

--- a/hanu-reference/service-mesh/site-values.yaml
+++ b/hanu-reference/service-mesh/site-values.yaml
@@ -4,7 +4,6 @@ metadata:
   name: site
 
 global:
-  repository: https://VM-NAME-1:8879/
   serviceMeshControlNodeSelector:
     servicemesh: enabled
   serviceMeshIngressNodeSelector:
@@ -24,8 +23,6 @@ global:
 
 charts:
 - name: istio-operator
-  source:
-    repository: $(repository)
   override:
     revision: $(istioRevision)
     hub: docker.io/istio
@@ -36,8 +33,6 @@ charts:
     operator.resources.requests.memory: 128Mi
 
 - name: servicemesh-controlplane
-  source:
-    repository: $(repository)
   override:
     IstioOperator.revision: $(istioRevision)
     IstioOperator.image.hub: docker.io/istio
@@ -56,8 +51,6 @@ charts:
     IstioOperator.components.pilot.k8s.nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-gateway
-  source:
-    repository: $(repository)
   override:
     IstioOperator.revision: $(istioRevision)
     IstioOperator.image.hub: docker.io/istio
@@ -84,14 +77,10 @@ charts:
     IstioOperator.components.egressGateways.k8s.nodeSelector: $(serviceMeshEgressNodeSelector)
 
 - name: jaeger-operator
-  source:
-    repository: $(repository)
   override:
     nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-jaeger-resource
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     logLevel: debug
@@ -119,14 +108,10 @@ charts:
                   number: 16686
 
 - name: kiali-operator
-  source:
-    repository: $(repository)
   override:
     nodeSelector: $(serviceMeshControlNodeSelector)
 
 - name: servicemesh-kiali-resource
-  source:
-    repository: $(repository)
   override:
     istioComponentNamespaces.prometheus: lma
     istioNamespace: istio-system
@@ -159,22 +144,16 @@ charts:
                   number: 20001
 
 - name: servicemesh-grafana-dashboard
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
 
 - name: servicemesh-prometheusmonitor
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     istio.interval: "15s"
     jaeger.interval: "15s"
 
 - name: servicemesh-prometheusrule
-  source:
-    repository: $(repository)
   override:
     namespace: istio-system
     aggregation.interval: "15s"


### PR DESCRIPTION
helm-chart 가 먼저 적용되어야 함.
관련 PR: [openinfradev/helm-charts/pull/48]

decapod-base-yaml 이 함께 적용되어야 함
관련 PR: [openinfradev/decapod-base-yaml/pull/88]

site-values.yaml 을 추가하여 values 값을 오버라이드 할 수 있게 수정

아래 label 을 노드에 추가해야 함 (추후 tacoplay 에 추가 예정)

1. servicemesh control node
    servicemesh=enabled

2. servicemesh ingress node
    taco-ingress-gateway=enabled

3. servicemesh egress node
    taco-egress-gateway=enabled
