### PR TITLE
Add prepare-etcd-secret chart for lma

### DIFF
--- a/hanu-reference/lma/site-values.yaml
+++ b/hanu-reference/lma/site-values.yaml
@@ -183,3 +183,12 @@ charts:
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints:
       - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)
+
+- name: prepare-etcd-secret
+  override:
+    nodeSelector:
+      "node-role.kubernetes.io/master": ""
+    tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+        operator: "Exists"


### PR DESCRIPTION
의존성: 아래 PR이 먼저 머지가 되어야합니다.

- https://github.com/openinfradev/helm-charts/pull/67  (완료)
- https://github.com/openinfradev/decapod-base-yaml/pull/110 (완료)

아마존 환경에서 테스트한 마스터노드 label, toleration을 추가하였습니다. 