### PR TITLE
hanu-reference-offline/lma sync with hanu-reference

### DIFF
--- a/hanu-reference-offline/lma/image-values.yaml
+++ b/hanu-reference-offline/lma/image-values.yaml
@@ -93,19 +93,6 @@ charts:
     image.repository: $(registry)/k8s-prometheus-adapter-amd64
     image.tag: v0.7.0
 
-- name: prometheus-fed-master
-  override:
-    alertmanager.alertmanagerSpec.image.repository: $(registry)/prometheus/alertmanager
-    alertmanager.alertmanagerSpec.image.tag: v0.21.0
-    prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
-    prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
-    prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
-    prometheusOperator.image.tag: v0.46.0
-    prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
-    prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
-    prometheus.prometheusSpec.image.tag: v2.24.0
-
 - name: prometheus-node-exporter
   override:
     image.repository: $(registry)/prometheus/node-exporter

--- a/hanu-reference-offline/lma/site-values.yaml
+++ b/hanu-reference-offline/lma/site-values.yaml
@@ -33,21 +33,14 @@ charts:
     kubeEtcd.endpoints:
     - 172.27.1.222
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
-    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 10Gi
+    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi
     prometheus.prometheusSpec.retention: 2d
     prometheus.prometheusSpec.externalLabels.taco_cluster: dev
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
     
-- name: prometheus-fed-master
-  source:
-    repository: $(repository)
-  override:
     alertmanager.alertmanagerSpec.nodeSelector: $(nodeSelector)
     alertmanager.alertmanagerSpec.retention: 2h
     alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
-    prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
-    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
-    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi
 
 - name: prometheus-node-exporter
   source:
@@ -156,14 +149,6 @@ charts:
     serviceMonitor.kubelet.interval: 30s
     serviceMonitor.additionalScrapeConfigs:
     metricbeat.enabled: false
-    metricbeat.elasticsearch.host: https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200
-    metricbeat.kibana.host: eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
-    metricbeat.prometheus.hosts:
-    - fed-master-prometheus.fed.svc.$(clusterName):9090
-    # tacoWatcher.host: taco-watcher.fed.svc.$(clusterName)
-    # tacoWatcher.joinCluster.body.kibanaUrl: http://eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
-    # tacoWatcher.joinCluster.body.grafanaUrl: http://grafana.fed.svc.$(clusterName)
-    # tacoWatcher.joinCluster.body.k8sUrl: https://kubernetes.default.svc.$(clusterName)
     kibanaInit.url: http://eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
 
 - name: prometheus-adapter

--- a/hanu-reference-offline/lma/site-values.yaml
+++ b/hanu-reference-offline/lma/site-values.yaml
@@ -37,7 +37,10 @@ charts:
     prometheus.prometheusSpec.retention: 2d
     prometheus.prometheusSpec.externalLabels.taco_cluster: dev
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
-    
+
+    alertmanager.service.type: NodePort
+    alertmanager.service.nodePort: 30111
+    alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
     alertmanager.alertmanagerSpec.nodeSelector: $(nodeSelector)
     alertmanager.alertmanagerSpec.retention: 2h
     alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
@@ -170,21 +173,16 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     clusterDomain: $(clusterName)
-    objstoreConfig: |-
-      type: s3
-      config:
-        bucket: thanos
-        endpoint: {{ include "thanos.minio.fullname" . }}.fed.svc.$(clusterName):9000
-        access_key: $(defaultUser)
-        secret_key: $(defaultPassword)
-        insecure: true
+    existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     queryFrontend.nodeSelector: $(nodeSelector)
     queryFrontend.service.type: NodePort
     queryFrontend.service.http.nodePort: 30007
     querier.stores:
     - prometheus-operated.lma.svc.$(clusterName):10901
+    bucketweb.enabled: $(thanosPrimaryCluster)
     bucketweb.nodeSelector: $(nodeSelector)
+    compactor.enabled: $(thanosPrimaryCluster)
     compactor.nodeSelector: $(nodeSelector)
     storegateway.nodeSelector: $(nodeSelector)
     compactor.persistence.size: 8Gi
@@ -192,9 +190,10 @@ charts:
     # - --compact.enable-vertical-compaction
     # - --deduplication.replica-label="replica"
     storegateway.persistence.size: 8Gi
+    ruler.enabled: $(thanosPrimaryCluster)
     ruler.nodeSelector: $(nodeSelector)
     ruler.alertmanagers:
-    - http://fed-master-alertmanager.fed.svc.$(clusterName):9093
+    - http://fed-master-alertmanager.lma.svc.$(clusterName):9093
     ruler.persistence.size: 8Gi
     minio.accessKey.password: $(defaultUser)
     minio.secretKey.password: $(defaultPassword)
@@ -202,3 +201,17 @@ charts:
     minio.persistence.storageClass: $(storageClassName)
     minio.persistence.accessMode: ReadWriteOnce
     minio.persistence.size: 10Gi
+
+- name: thanos-config
+  source:
+    repository: $(repository)
+  override:
+    objectStorage:
+      bucketName: thanos
+      endpoint: thanos-minio.lma.svc.$(clusterName):9000
+      access_key: $(defaultUser)
+      secret_key: $(defaultPassword)
+      secretName: $(thanosObjstoreSecret)
+    sidecarsService.name: thanos-sidecars
+    sidecarsService.endpoints:
+      - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)


### PR DESCRIPTION
https://github.com/openinfradev/decapod-site/pull/57 에서 발생하는 validation 오류 (hanu-reference-offline 사이트의 fed-master 삭제 부분 누락) 등을 수정하기 위해서 hanu-reference 내용과 동기화하였습니다.