### PR TITLE
Change to grafana discovery all namesapce

### DIFF
--- a/hanu-reference/lma/site-values.yaml
+++ b/hanu-reference/lma/site-values.yaml
@@ -80,6 +80,7 @@ charts:
   override:
     adminPassword: password
     persistence.storageClassName: $(storageClassName)
+    sidecar.dashboards.searchNamespace: ALL
 
 - name: fluentbit-operator
   override:
@@ -129,6 +130,12 @@ charts:
     serviceMonitor.additionalScrapeConfigs:
     metricbeat.enabled: false
     kibanaInit.url: http://eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
+    grafanaDashboard.istio.enabled: false
+    grafanaDashboard.jaeger.enabled: false
+    serviceMonitor.istio.enabled: false
+    serviceMonitor.jaeger.enabled: false
+    prometheusRules.istio.aggregation.enabled: false
+    prometheusRules.istio.optimization.enabled: false
 
 - name: prometheus-adapter
   override:

--- a/hanu-reference/service-mesh/site-values.yaml
+++ b/hanu-reference/service-mesh/site-values.yaml
@@ -65,7 +65,8 @@ charts:
     IstioOperator.components.ingressGateways.k8s.hpaSpec.minReplicas: 1
     IstioOperator.components.ingressGateways.k8s.nodeSelector: $(serviceMeshIngressNodeSelector)
     IstioOperator.components.ingressGateways.k8s.service.type: NodePort
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpNodePort: 31081
+    IstioOperator.components.ingressGateways.k8s.service.ports.statusNodePort: 31021
+    IstioOperator.components.ingressGateways.k8s.service.ports.httpNodePort: 31080
     IstioOperator.components.ingressGateways.k8s.service.ports.httpsNodePort: 31443
     IstioOperator.components.egressGateways.name: istio-egress-gateway
     IstioOperator.components.egressGateways.namespace: istio-system
@@ -92,6 +93,7 @@ charts:
       serverUrls: https://eck-elasticsearch-es-http.lma.svc:9200
       username: elastic
       password: tacoword
+    query.basePath: /
     JaegerIngress:
       enabled: true
       namespace: istio-system
@@ -146,6 +148,8 @@ charts:
 - name: servicemesh-grafana-dashboard
   override:
     namespace: istio-system
+    dashboards:
+      label: grafana_dashboard
 
 - name: servicemesh-prometheusmonitor
   override:


### PR DESCRIPTION
LMA 의 grafana 가 모든 namespace 의 cm 을 discovery 할 수 있게 변경 (istio-namespace 의 grafana dashboard 를 찾을 수 있게 수정)
LMA addons 에 있는 istio 관련 리소스(grafana dashboard, ServiceMonitor, PodMonitor, Prometheusrule) 을 disable 시킴
istio 의 grafana dashboard 의 label 을 grafana 가 discovery 할 수 있게 "grafana_dashboard" 로 변경
ELB 와 istio gateway 를 연결할 수 있게 istio gateway 의 health check nodeport 를 지정할 수 있게 변경
Jaeger 의 web base path 를 "/" 로 추가