### PR TITLE
hanu-reference-offline: fix image urls

### DIFF
--- a/hanu-reference-offline/lma/image-values.yaml
+++ b/hanu-reference-offline/lma/image-values.yaml
@@ -20,7 +20,7 @@ charts:
 
 - name: addons
   override:
-    kibanaInit.image.repository: $(registry)/kibana-init
+    kibanaInit.image.repository: $(registry)/sktdev/kibana-init
     kibanaInit.image.tag: v4
     metricbeat.image.repository: $(registry)/metricbeat
     metricbeat.image.tag: taco-1.0.0
@@ -29,30 +29,30 @@ charts:
 
 - name: fluentbit
   override:
-    image.exporter.repository: $(registry)/logalert-exporter
+    image.exporter.repository: $(registry)/siim/logalert-exporter
     image.exporter.tag: v0.1.1
-    image.fluentbit.repository: $(registry)/fluent-bit-for-operator
+    image.fluentbit.repository: $(registry)/siim/fluent-bit-for-operator
     image.fluentbit.tag: v1.4.6
     image.hyperkube.repository: $(registry)/hyperkube
     image.hyperkube.tag: v1.17.6
     image.init.repository: $(registry)/library/docker
     image.init.tag: 19.03
-    image.operator.repository: $(registry)/fluentbit-operator
+    image.operator.repository: $(registry)/siim/fluentbit-operator
     image.operator.tag: v0.1.1
     image.elasticsearchTemplates.repository: $(registry)/openstackhelm/heat
     image.elasticsearchTemplates.tag: newton
 
 - name: fluentbit-operator
   override:
-    image.exporter.repository: $(registry)/logalert-exporter
+    image.exporter.repository: $(registry)/siim/logalert-exporter
     image.exporter.tag: v0.1.1
-    image.fluentbit.repository: $(registry)/fluent-bit-for-operator
+    image.fluentbit.repository: $(registry)/siim/fluent-bit-for-operator
     image.fluentbit.tag: v1.4.6
     image.hyperkube.repository: $(registry)/hyperkube
     image.hyperkube.tag: v1.17.6
     image.init.repository: $(registry)/library/docker
     image.init.tag: 19.03
-    image.operator.repository: $(registry)/fluentbit-operator
+    image.operator.repository: $(registry)/siim/fluentbit-operator
     image.operator.tag: v0.1.1
     image.elasticsearchTemplates.repository: $(registry)/openstackhelm/heat
     image.elasticsearchTemplates.tag: newton
@@ -61,11 +61,11 @@ charts:
   override:
     downloadDashboardsImage.repository: $(registry)/curl
     downloadDashboardsImage.tag: 7.70.0
-    image.repository: $(registry)/grafana
+    image.repository: $(registry)/grafana/grafana
     image.tag: 7.1.1
     initChownData.image.repository: $(registry)/library/busybox
     initChownData.image.tag: 1.31.1
-    sidecar.image.repository: $(registry)/k8s-sidecar
+    sidecar.image.repository: $(registry)/kiwigrid/k8s-sidecar
     sidecar.image.tag: 0.1.151
     testFramework.image: $(registry)/bats
     testFramework.tag: v1.1.0
@@ -80,7 +80,7 @@ charts:
   override:
     alertmanager.alertmanagerSpec.image.repository: $(registry)/prometheus/alertmanager
     alertmanager.alertmanagerSpec.image.tag: v0.21.0
-    prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
+    prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/jettech/kube-webhook-certgen
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
     prometheusOperator.image.tag: v0.46.0
@@ -91,7 +91,7 @@ charts:
 
 - name: prometheus-adapter
   override:
-    image.repository: $(registry)/k8s-prometheus-adapter-amd64
+    image.repository: $(registry)/directxman12/k8s-prometheus-adapter-amd64
     image.tag: v0.7.0
 
 - name: prometheus-node-exporter
@@ -103,7 +103,7 @@ charts:
   override:
     alertmanager.alertmanagerSpec.image.repository: $(registry)/prometheus/alertmanager
     alertmanager.alertmanagerSpec.image.tag: v0.21.0
-    prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
+    prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/jettech/kube-webhook-certgen
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
     prometheusOperator.image.tag: v0.46.0
@@ -116,11 +116,11 @@ charts:
   override:
     images.tags.dep_check: $(registry)/airshipit/kubernetes-entrypoint:v1.0.0
     images.tags.image_repo_sync: $(registry)/library/docker:17.07.0
-    images.tags.process_exporter: $(registry)/process-exporter:0.2.11
+    images.tags.process_exporter: $(registry)/ncabatoff/process-exporter:0.2.11
 
 - name: prometheus-pushgateway
   override:
-    image.repository: $(registry)/pushgateway
+    image.repository: $(registry)/prom/pushgateway
     image.tag: v1.3.0
 
 - name: kubernetes-event-exporter


### PR DESCRIPTION
https://github.com/openinfradev/tacoplay/commit/32d7eb56d3d5c8777059474f150822d30a1be84b 반영으로 site-prepare 과정에서 오프라인 환경을 위한 이미지 태깅 형식이 변경되어 이를 반영합니다.

컨테이너 레지스트리 주소 없이 묵시적으로 docker.io를 사용하는 이미지 주소의 경우,
- 기존: organization 부분이 제거되어 내부 레지스트리에 저장 (예: ORG/IMAGE_A -> private_registry:5000/IMAGE_A)
- 변경: 원본 주소 값에 내부 레지스트리 내용만 추가 (예: ORG/IMAGE_A -> private_registry:5000/ORG/IMAGE_A)