### PR TITLE
Upgrade service-mesh version

### DIFF
--- a/hanu-reference-offline/service-mesh/image-values.yaml
+++ b/hanu-reference-offline/service-mesh/image-values.yaml
@@ -6,44 +6,30 @@ global:
   registry: ${LOCAL_REGISTRY}:5000
 
 charts:
-- name: istio-operator
+- name: istiod
   override:
-    hub: $(registry)/istio
-    tag: 1.10.2
+    hub: $(registry)/istio/pilot
+    tag: 1.13.1
+
+- name: istio-ingress-gateway
+  override:
+    hub: $(registry)/istio/proxyv2
+    tag: 1.13.1
 
 - name: jaeger-operator
   override:
     image.repository: $(registry)jaegertracing/jaeger-operator
-    image.tag: 1.21.2
+    image.tag: 1.29.1
+    collectorImage.repository: $(registry)/jaegertracing/jaeger-collector
+    collectorImage.tag: 1.29.1
+    agentImage.repository: $(registry)/jaegertracing/jaeger-agent
+    agentImage.tag: 1.29.1
+    ingesterImage.repository: $(registry)/jaegertracing/jaeger-ingester
+    ingesterImage.tag: 1.29.1
+    queryImage.repository: $(registry)/jaegertracing/jaeger-collector
+    queryImage.tag: 1.29.1
 
 - name: kiali-operator
   override:
     image.repo: $(registry)/kiali/kiali-operator
-    image.tag: v1.34.0
-
-- name: servicemesh-controlplane
-  override: {}
-
-- name: servicemesh-gateway
-  override: {}
-
-- name: jaeger-operator
-  override: {}
-
-- name: servicemesh-jaeger-resource
-  override: {}
-
-- name: kiali-operator
-  override: {}
-
-- name: servicemesh-kiali-resource
-  override: {}
-
-- name: servicemesh-grafana-dashboard
-  override: {}
-
-- name: servicemesh-prometheusmonitor
-  override: {}
-
-- name: servicemesh-prometheusrule
-  override: {}
+    image.tag: v1.45.1

--- a/hanu-reference-offline/service-mesh/site-values.yaml
+++ b/hanu-reference-offline/service-mesh/site-values.yaml
@@ -5,181 +5,75 @@ metadata:
 
 global:
   repository: ${LOCAL_HELM_REPO}
+  clusterName: cluster.local
   serviceMeshControlNodeSelector:
     servicemesh: enabled
   serviceMeshIngressNodeSelector:
     taco-ingress-gateway: enabled
   serviceMeshEgressNodeSelector:
     taco-egress-gateway: enabled
-  ingressGatewayLabel:
-    gateway: taco-ingress
-  egressGatewayLabel:
-    gateway: taco-egress
-  clusterName: cluster.local
-  storageClassName: taco-storage
-  istioRevision: "1-10-2"
-  istioImageTag: "1.10.2"
-  jaegerDomain: jaeger.k2-node01
-  kialiDomain: kiali.k2-node01
+  ingressGatewayLabel: istio-ingress-gateway
+  egressGatewayLabel: istio-egress-gateway
 
 charts:
-- name: istio-operator
+- name: istiod
   source:
     repository: $(repository)
   override:
-    revision: $(istioRevision)
-    hub: docker.io/istio
-    tag: $(istioImageTag)
-    operator.resources.limits.cpu: 200m
-    operator.resources.limits.memory: 256Mi
-    operator.resources.requests.cpu: 50m
-    operator.resources.requests.memory: 128Mi
+    pilot.traceSampling: 1.0
 
-- name: servicemesh-controlplane
+- name: istio-ingress-gateway
   source:
     repository: $(repository)
   override:
-    IstioOperator.revision: $(istioRevision)
-    IstioOperator.image.hub: docker.io/istio
-    IstioOperator.image.tag: $(istioImageTag)
-    IstioOperator.meshConfig.enableTracing: true
-    IstioOperator.meshConfig.tracingSampling: 100
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.service: jaeger-operator-jaeger-collector.istio-system.svc
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.port: 14250
-    IstioOperator.meshConfig.defaultConfig.discoveryAddress: istiod-$(istioRevision).istio-system.svc:15012
-    IstioOperator.meshConfig.defaultConfig.tracing.zipkin.address: jaeger-operator-jaeger-collector.istio-system.svc:9411
-    IstioOperator.meshConfig.defaultConfig.tracing.sampling: 100
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.pilot.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.pilot.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.pilot.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.pilot.k8s.nodeSelector: $(serviceMeshControlNodeSelector)
-
-- name: servicemesh-gateway
-  source:
-    repository: $(repository)
-  override:
-    IstioOperator.revision: $(istioRevision)
-    IstioOperator.image.hub: docker.io/istio
-    IstioOperator.image.tag: $(istioImageTag)
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.ingressGateways.name: istio-ingress-gateway
-    IstioOperator.components.ingressGateways.namespace: istio-system
-    IstioOperator.components.ingressGateways.label: $(ingressGatewayLabel)
-    IstioOperator.components.ingressGateways.enabled: true
-    IstioOperator.components.ingressGateways.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.ingressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.ingressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.ingressGateways.k8s.nodeSelector: $(serviceMeshIngressNodeSelector)
-    IstioOperator.components.ingressGateways.k8s.service.type: NodePort
-    IstioOperator.components.ingressGateways.k8s.service.ports.statusNodePort: 31021
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpNodePort: 31080
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpsNodePort: 31443
-    IstioOperator.components.egressGateways.name: istio-egress-gateway
-    IstioOperator.components.egressGateways.namespace: istio-system
-    IstioOperator.components.egressGateways.label: $(egressGatewayLabel)
-    IstioOperator.components.egressGateways.enabled: false
-    IstioOperator.components.egressGateways.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.egressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.egressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.egressGateways.k8s.nodeSelector: $(serviceMeshEgressNodeSelector)
+    replicaCount: 1
+    service.type: LoadBalancer
+    resources.requests.cpu: 1000m
+    resources.requests.memory: 1024Mi
+    resources.limits.cpu: 2000m
+    resources.limits.memory: 2048Mi
 
 - name: jaeger-operator
-  source:
-    repository: $(repository)
-  override:
-    nodeSelector: $(serviceMeshControlNodeSelector)
+  override: {}
 
 - name: servicemesh-jaeger-resource
   source:
     repository: $(repository)
   override:
-    namespace: istio-system
-    logLevel: debug
-    collector.resources.requests.cpu: 500m
-    collector.resources.requests.memory: 1Gi
-    collector.resources.limits.cpu: '1'
-    collector.resources.limits.memory: 2Gi
+    sampling.param: 100
     storage.options.es:
       serverUrls: https://eck-elasticsearch-es-http.lma.svc:9200
-      username: elastic
+      username: taco-jaeger
       password: tacoword
-    query.basePath: /
-    JaegerIngress:
-      enabled: true
-      namespace: istio-system
-      rules:
-      - host: $(jaegerDomain)
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: jaeger-operator-jaeger-query
-                port:
-                  number: 16686
+    elasticsearch:
+      host: eck-elasticsearch-es-http.lma.svc.$(clusterName)
+      user:
+        enabled: false
+        username: taco-jaeger
+        password: tacoword
 
 - name: kiali-operator
-  source:
-    repository: $(repository)
-  override:
-    nodeSelector: $(serviceMeshControlNodeSelector)
+  override: {}
 
 - name: servicemesh-kiali-resource
   source:
     repository: $(repository)
   override:
-    istioComponentNamespaces.prometheus: lma
-    istioNamespace: istio-system
-    deployment.resources.requests.cpu: 500m
-    deployment.resources.requests.memory: 1024Mi
-    deployment.resources.limits.cpu: 1000m
-    deployment.resources.limits.memory: 2048Mi
-    deployment.nodeSelector: $(serviceMeshControlNodeSelector)
-    externalServices.istio.configMapName: istio-$(istioRevision)
-    externalServices.istio.istioIdentityDomain: "svc.cluster.local"
+    auth.strategy: anonymous
     externalServices.prometheus.url: http://lma-prometheus.lma.svc:9090
     externalServices.tracing.inClusterUrl: http://jaeger-operator-jaeger-query.istio-system:16686
+    externalServices.grafana.auth.type: basic
     externalServices.grafana.auth.username: admin
     externalServices.grafana.auth.password: password
     externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
-    externalServices.grafana.url: http://VM-NAME-1:30009
-    KialiIngress:
-      enabled: true
-      namespace: istio-system
-      rules:
-      - host: $(kialiDomain)
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kaili
-                port:
-                  number: 20001
-
-- name: servicemesh-grafana-dashboard
-  source:
-    repository: $(repository)
-  override:
-    namespace: istio-system
-    dashboards:
-      label: grafana_dashboard
+    externalServices.grafana.url: https://grafana-v2.taco-cat.xyz
 
 - name: servicemesh-prometheusmonitor
   source:
     repository: $(repository)
-  override:
-    namespace: istio-system
-    istio.interval: "15s"
-    jaeger.interval: "15s"
+  override: {}
 
 - name: servicemesh-prometheusrule
   source:
     repository: $(repository)
-  override:
-    namespace: istio-system
-    aggregation.interval: "15s"
-    optimization.interval: "15s"
+  override: {}

--- a/hanu-reference/service-mesh/site-values.yaml
+++ b/hanu-reference/service-mesh/site-values.yaml
@@ -4,130 +4,57 @@ metadata:
   name: site
 
 global:
+  clusterName: cluster.local
   serviceMeshControlNodeSelector:
     servicemesh: enabled
   serviceMeshIngressNodeSelector:
     taco-ingress-gateway: enabled
   serviceMeshEgressNodeSelector:
     taco-egress-gateway: enabled
-  ingressGatewayLabel:
-    gateway: taco-ingress
-  egressGatewayLabel:
-    gateway: taco-egress
-  clusterName: cluster.local
-  storageClassName: taco-storage
-  istioRevision: "1-11-7"
-  jaegerDomain: jaeger.k2-node01
-  kialiDomain: kiali.k2-node01
+  ingressGatewayLabel: istio-ingress-gateway
+  egressGatewayLabel: istio-egress-gateway
 
 charts:
-- name: istio-operator
+- name: istiod
   override:
-    revision: $(istioRevision)
-    operator.resources.limits.cpu: 200m
-    operator.resources.limits.memory: 256Mi
-    operator.resources.requests.cpu: 50m
-    operator.resources.requests.memory: 128Mi
+    pilot.traceSampling: 1.0
 
-- name: servicemesh-controlplane
+- name: istio-ingress-gateway
   override:
-    IstioOperator.revision: $(istioRevision)
-    IstioOperator.meshConfig.enableTracing: true
-    IstioOperator.meshConfig.tracingSampling: 100
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.service: jaeger-operator-jaeger-collector.istio-system.svc
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.port: 14250
-    IstioOperator.meshConfig.defaultConfig.discoveryAddress: istiod-$(istioRevision).istio-system.svc:15012
-    IstioOperator.meshConfig.defaultConfig.tracing.zipkin.address: jaeger-operator-jaeger-collector.istio-system.svc:9411
-    IstioOperator.meshConfig.defaultConfig.tracing.sampling: 100
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.pilot.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.pilot.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.pilot.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.pilot.k8s.nodeSelector: $(serviceMeshControlNodeSelector)
-
-- name: servicemesh-gateway
-  override:
-    IstioOperator.revision: $(istioRevision)
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.ingressGateways.name: istio-ingress-gateway
-    IstioOperator.components.ingressGateways.namespace: istio-system
-    IstioOperator.components.ingressGateways.label: $(ingressGatewayLabel)
-    IstioOperator.components.ingressGateways.enabled: true
-    IstioOperator.components.ingressGateways.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.ingressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.ingressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.ingressGateways.k8s.nodeSelector: $(serviceMeshIngressNodeSelector)
-    IstioOperator.components.ingressGateways.k8s.service.type: NodePort
-    IstioOperator.components.ingressGateways.k8s.service.ports.statusNodePort: 31021
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpNodePort: 31080
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpsNodePort: 31443
-    IstioOperator.components.egressGateways.name: istio-egress-gateway
-    IstioOperator.components.egressGateways.namespace: istio-system
-    IstioOperator.components.egressGateways.label: $(egressGatewayLabel)
-    IstioOperator.components.egressGateways.enabled: false
-    IstioOperator.components.egressGateways.k8s.resources.requests.cpu: 500m
-    IstioOperator.components.egressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.egressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.egressGateways.k8s.nodeSelector: $(serviceMeshEgressNodeSelector)
+    replicaCount: 1
+    service.type: LoadBalancer
+    resources.requests.cpu: 1000m
+    resources.requests.memory: 1024Mi
+    resources.limits.cpu: 2000m
+    resources.limits.memory: 2048Mi
 
 - name: jaeger-operator
-  override:
-    nodeSelector: $(serviceMeshControlNodeSelector)
+  override: {}
 
 - name: servicemesh-jaeger-resource
   override:
-    namespace: istio-system
-    logLevel: debug
-    collector.resources.requests.cpu: 500m
-    collector.resources.requests.memory: 1Gi
-    collector.resources.limits.cpu: '1'
-    collector.resources.limits.memory: 2Gi
+    sampling.param: 100
     storage.options.es:
       serverUrls: https://eck-elasticsearch-es-http.lma.svc:9200
-      username: elastic
+      username: taco-jaeger
       password: tacoword
-    query.basePath: /
-    JaegerIngress:
-      enabled: false
+    elasticsearch:
+      host: eck-elasticsearch-es-http.lma.svc.$(clusterName)
+      user:
+        enabled: false
+        username: taco-jaeger
+        password: tacoword
 
 - name: kiali-operator
-  override:
-    nodeSelector: $(serviceMeshControlNodeSelector)
+  override: {}
 
 - name: servicemesh-kiali-resource
   override:
-    istioComponentNamespaces.prometheus: lma
-    istioNamespace: istio-system
-    deployment.resources.requests.cpu: 500m
-    deployment.resources.requests.memory: 1024Mi
-    deployment.resources.limits.cpu: 1000m
-    deployment.resources.limits.memory: 2048Mi
-    deployment.nodeSelector: $(serviceMeshControlNodeSelector)
-    externalServices.istio.configMapName: istio-$(istioRevision)
-    externalServices.istio.istioIdentityDomain: "svc.cluster.local"
+    auth.strategy: anonymous
     externalServices.prometheus.url: http://lma-prometheus.lma.svc:9090
     externalServices.tracing.inClusterUrl: http://jaeger-operator-jaeger-query.istio-system:16686
+    externalServices.grafana.auth.type: basic
     externalServices.grafana.auth.username: admin
     externalServices.grafana.auth.password: password
     externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
-    externalServices.grafana.url: http://VM-NAME-1:30009
-    KialiIngress:
-      enabled: false
-
-- name: servicemesh-grafana-dashboard
-  override:
-    namespace: istio-system
-    dashboards:
-      label: grafana_dashboard
-
-- name: servicemesh-prometheusmonitor
-  override:
-    namespace: istio-system
-    istio.interval: "15s"
-    jaeger.interval: "15s"
-
-- name: servicemesh-prometheusrule
-  override:
-    namespace: istio-system
-    aggregation.interval: "15s"
-    optimization.interval: "15s"
+    externalServices.grafana.url: https://grafana-v2.taco-cat.xyz


### PR DESCRIPTION
Change istio operator to istio helm charts

Upgrade charts
- istio-1.13.1
- jaeger-operator-2.27.1 (app: v1.29.1)
- kiali-operator-1.45.1 (app: v1.45.1)
- istio-grafana-dashboard-1.13.1