### PR TITLE
lma: prometheus: fix kubeetcd endpoints

### DIFF
--- a/hanu-reference-offline/lma/site-values.yaml
+++ b/hanu-reference-offline/lma/site-values.yaml
@@ -30,8 +30,6 @@ charts:
   source:
     repository: $(repository)
   override:
-    kubeEtcd.endpoints:
-    - 172.27.1.222
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi
     prometheus.prometheusSpec.retention: 2d

--- a/hanu-reference/lma/site-values.yaml
+++ b/hanu-reference/lma/site-values.yaml
@@ -24,8 +24,6 @@ charts:
 
 - name: prometheus
   override:
-    kubeEtcd.endpoints:
-    - 172.27.1.222
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi
     prometheus.prometheusSpec.retention: 2d


### PR DESCRIPTION
kube-prometheus-stack 차트는 POD로 실행되는 etcd의 exporter 아이피를 서비스 셀렉터를 통해 자동 구성하는 방법을 지원합니다. 이를 위해 kubeEtcd.endpoints 리스트가 비어 있어야 하기 때문에 해당 내용으로 정리하였습니다.