### PR TITLE
Adopting servicemesh dashboard

### DIFF
--- a/hanu-reference/lma/site-values.yaml
+++ b/hanu-reference/lma/site-values.yaml
@@ -59,6 +59,8 @@ charts:
 - name: eck-resource
   override:
     kibana.nodeSelector: $(nodeSelector)
+    kibana.server.basePath: /kibana
+    kibana.readinessPath: /kibana/login
     
     elasticsearch.nodeSets.master.nodeSelector: $(nodeSelector)
     elasticsearch.nodeSets.master.count: 1

--- a/hanu-reference/lma/site-values.yaml
+++ b/hanu-reference/lma/site-values.yaml
@@ -14,6 +14,11 @@ global:
   defaultUser: taco
   thanosObjstoreSecret: taco-objstore-secret
   thanosPrimaryCluster: false
+  # servicemesh dashboard and grafana
+  realms: 04a70f29
+  serviceDomain: taco-cat.xyz
+  keycloakDomain: keycloak-eom.taco-cat.xyz
+  grafanaClientSecret: JLtsanYtrCg21RGxrcVmQP0GeuDFUhpA
 
 charts:
 - name: prometheus-operator
@@ -79,6 +84,33 @@ charts:
     adminPassword: password
     persistence.storageClassName: $(storageClassName)
     sidecar.dashboards.searchNamespace: ALL
+    # grafana oidc
+    service.type: ClusterIP
+    grafana.ini.server:
+      domain: dashboard-$(realms).$(serviceDomain)
+      root_url: https://dashboard-$(realms).$(serviceDomain)/grafana
+      serve_from_sub_path: true
+    grafana.ini.auth.generic_oauth:
+      enabled: true
+      name: keycloak
+      allow_sign_up: true
+      client_id: grafana
+      client_secret: $(grafanaClientSecret)
+      scopes: openid profile email
+      auth_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/auth
+      token_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/token
+      api_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/userinfo
+    grafana.ini.auth:
+      disable_login_form: false
+      oauth_auto_login: true
+      disable_signout_menu: true
+    grafana.ini.security:
+      allow_embedding: true
+      cookie_secure: true
+      cookie_samesite: none
+    grafana.ini.user:
+      auto_assign_org: true
+      auto_assign_org_role: Admin
 
 - name: fluentbit-operator
   override:

--- a/hanu-reference/service-mesh/site-values.yaml
+++ b/hanu-reference/service-mesh/site-values.yaml
@@ -44,6 +44,7 @@ charts:
         enabled: false
         username: taco-jaeger
         password: tacoword
+    query.basePath: /jaeger
 
 - name: kiali-operator
   override: {}
@@ -58,3 +59,4 @@ charts:
     externalServices.grafana.auth.password: password
     externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
     externalServices.grafana.url: https://grafana-v2.taco-cat.xyz
+    server.webRoot: /kiali


### PR DESCRIPTION
- change jaeger, kiali web root
- adopt grafana oidc

* lma 의 grafana.ini 은 값이 override 되지 않는다. 변환할 때 yaml 의 key 값에 "." 이 추가 되면 변환 못시키는 것 같음.
* grafana chart 의 value.yaml 을 보면 grafana.ini:  key 값이 있는데 helm chart 에서는 이 key 를 인식하나 decapod 에서는 인식 못함
* 그렇다 하더라도 추후 변환될 것을 고려하여 override 값을 추가하였음

- 아래 rendering 된 이후에 값들이 변경되므로 workflow 에서 keycloak 에 realms, client 가 생성되면 결과 값을 가져다가 다시 rendering 해야 함. 즉, site.yaml 에서 결정할 수 없는 값이므로 예제 값을 넣었음.
realms: 04a70f29
serviceDomain: taco-cat.xyz
keycloakDomain: keycloak-eom.taco-cat.xyz
grafanaClientSecret: JLtsanYtrCg21RGxrcVmQP0GeuDFUhpA