### PR TITLE
Fix destination-github-username to repository owner

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -41,7 +41,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source-directory: 'output'
-          destination-github-username: 'openinfradev'
+          destination-github-username: ${{ github.repository_owner }}
           destination-repository-name: 'decapod-manifests'
           user-email: 'taco_support@sk.com'
           commit-message: See ORIGIN_COMMIT


### PR DESCRIPTION
decapod-site를 포크할 경우 github action에서 push하는 decapod-manifests가 openinfradev로 고정되어 있어,
이를 포크한 사용자의 계정을 사용하도록 변경

변경 전 포크하여 테스트 시 Push되는 decapod-manifest repo
`https://github.com/openinfradev/decapod-manifests`

변경 후 포크한 사용자 계정으로 Push
`https://github.com/Jaesang/decapod-manifests`