### PR TITLE
change the dns name for loki to kube-dns

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -33,7 +33,7 @@ charts:
     prometheus.prometheusSpec.retention: 2d
     prometheus.prometheusSpec.externalLabels.taco_cluster: $(clusterName)
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
-    
+
     alertmanager.service.type: NodePort
     alertmanager.service.nodePort: 30111
     alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
@@ -41,7 +41,7 @@ charts:
     alertmanager.alertmanagerSpec.retention: 2h
     alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
 
-- name: prometheus-node-exporter  
+- name: prometheus-node-exporter
   override:
     hostNetwork: false
 
@@ -98,11 +98,11 @@ charts:
     fluentbit:
       clusterName: $(clusterName)
       outputs:
-        loki: 
+        loki:
         - name: taco-loki
           host: loki-loki-distributed-gateway
           port: 80
-      targetLogs: 
+      targetLogs:
       - tag: kube.*
         bufferChunkSize: 2M
         bufferMaxSize: 5M
@@ -154,10 +154,10 @@ charts:
         config:
           path: "/tmp/kubernetes-event.log"
     addons:
-      loki: 
+      loki:
         enabled: true
         host: loki
-        port: 3100      
+        port: 3100
         target_file: "/tmp/kubernetes-event.log"
 
     conf.default.hosts:
@@ -216,3 +216,7 @@ charts:
       - key: "node-role.kubernetes.io/master"
         effect: "NoSchedule"
         operator: "Exists"
+
+- name: loki
+  override:
+    global.dnsService: kube-dns

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -33,7 +33,7 @@ charts:
     prometheus.prometheusSpec.retention: 2d
     prometheus.prometheusSpec.externalLabels.taco_cluster: $(clusterName)
     prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
-    
+
     alertmanager.service.type: NodePort
     alertmanager.service.nodePort: 30111
     alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
@@ -41,7 +41,7 @@ charts:
     alertmanager.alertmanagerSpec.retention: 2h
     alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
 
-- name: prometheus-node-exporter  
+- name: prometheus-node-exporter
   override:
     hostNetwork: false
 
@@ -98,11 +98,11 @@ charts:
     fluentbit:
       clusterName: $(clusterName)
       outputs:
-        loki: 
+        loki:
         - name: taco-loki
           host: loki-loki-distributed-gateway
           port: 80
-      targetLogs: 
+      targetLogs:
       - tag: kube.*
         bufferChunkSize: 2M
         bufferMaxSize: 5M
@@ -154,12 +154,12 @@ charts:
         config:
           path: "/tmp/kubernetes-event.log"
     addons:
-      loki: 
+      loki:
         enabled: true
         host: loki
-        port: 3100      
+        port: 3100
         target_file: "/tmp/kubernetes-event.log"
-        
+
     conf.default.hosts:
     - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
 
@@ -216,3 +216,7 @@ charts:
       - key: "node-role.kubernetes.io/master"
         effect: "NoSchedule"
         operator: "Exists"
+
+- name: loki
+  override:
+    global.dnsService: kube-dns


### PR DESCRIPTION
일자별 테스트가 에러나는 상황 
- 기존 하위호환을 위해 사용하던 kube-dns 서비스
- aws환경의 경우 kube-dns로 존재
- 21의 특정버전이후 이 지원이 삭제됨 https://kubernetes.io/docs/tasks/administer-cluster/coredns/#upgrading-an-existing-cluster-with-kubeadm 
- 추후에는 삭제하더라도 현재 상태 지원을 위해 site값으로 지정