### PR TITLE
change default for single cluster

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -145,6 +145,9 @@ charts:
     serviceMonitor.jaeger.enabled: false
     prometheusRules.istio.aggregation.enabled: false
     prometheusRules.istio.optimization.enabled: false
+    grafanaDatasource.prometheus.url: "lma-prometheus.lma:9090"
+    # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
+    grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 
 - name: prometheus-adapter
   override:
@@ -179,9 +182,7 @@ charts:
     queryFrontend.service.http.nodePort: 30007
     querier.stores:
     - prometheus-operated.lma.svc.$(clusterName):10901
-    bucketweb.enabled: $(thanosPrimaryCluster)
     bucketweb.nodeSelector: $(nodeSelector)
-    compactor.enabled: $(thanosPrimaryCluster)
     compactor.nodeSelector: $(nodeSelector)
     storegateway.nodeSelector: $(nodeSelector)
     compactor.persistence.size: 8Gi
@@ -189,7 +190,6 @@ charts:
     # - --compact.enable-vertical-compaction
     # - --deduplication.replica-label="replica"
     storegateway.persistence.size: 8Gi
-    ruler.enabled: $(thanosPrimaryCluster)
     ruler.nodeSelector: $(nodeSelector)
     ruler.alertmanagers:
     - http://fed-master-alertmanager.lma.svc.$(clusterName):9093


### PR DESCRIPTION
primary cluster의 적용을 위해 기반 형상을 정의 한다.
- 기본 형상을 single로 정의
  - prometheus <- grafana의 형태로 매트릭 조회 
  - 클러스터내 loki <- grafana의 형태로 로그 조회
- 위 설정관련 내역중 loki나 prometheus를 변수로 처리하여 primary 설정에서 해당 변수를 변경하여 처리할 수 있도록 함
- thanos형상도 하나로 통일 (primary 변수 제거) 
  - 모든 클러스터는 연합형상을 갖고 있지만 primary로 지정한 클러스터에만 thanos 배포