### PR TITLE
primary cluster 체계를 위한 기본값 변경

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -17,6 +17,10 @@ global:
 
   lokiHost: loki-loki-distributed-gateway
   lokiPort: 80
+  s3Host: minio.lma.svc
+  s3Port: 9000
+
+  grafanaDatasourceMetric: lma-prometheus.lma:9090
 
   # servicemesh dashboard and grafana
   realms: 04a70f29
@@ -145,7 +149,7 @@ charts:
     serviceMonitor.jaeger.enabled: false
     prometheusRules.istio.aggregation.enabled: false
     prometheusRules.istio.optimization.enabled: false
-    grafanaDatasource.prometheus.url: "lma-prometheus.lma:9090"
+    grafanaDatasource.prometheus.url: $(grafanaDatasourceMetric)
     # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
     grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 
@@ -191,6 +195,7 @@ charts:
     persistence.storageClass: $(storageClassName)
     persistence.size: 20Gi
     persistence.accessMode: ReadWriteOnce
+    service.type: LoadBalancer
 
 - name: thanos
   override:
@@ -220,7 +225,7 @@ charts:
   override:
     objectStorage:
       bucketName: thanos
-      endpoint: minio.lma.svc.$(clusterName):9000
+      endpoint: $(s3Host):$(s3Port)
       access_key: $(defaultUser)
       secret_key: $(defaultPassword)
       secretName: $(thanosObjstoreSecret)
@@ -240,3 +245,4 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
+    service.type: LoadBalancer


### PR DESCRIPTION
- 현재: grafana → thanos 구조를
- grafana → prometheus 구조로 바꿔줘야함
- 다음 변수를 사용하여 global에서 지정하여 사용
  - grafanaDatasourceMetric
- 추가로 loki와 minio를 LoadBalancer 타입으로 열어줘야 다른 조직(org)내 클러스터들이 접근할 수 있음…