### PR TITLE
Ack s3 bucket

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -100,5 +100,7 @@ charts:
     s3:
       enabled: true
       name:
-      - tks_thanos_$(clusterName)
-      - tks_loki_$(clusterName)
+      - tks-thanos
+      - tks-loki
+      # - tks-thanos-$(clusterName)
+      # - tks-loki-$(clusterName)


### PR DESCRIPTION
bucket 이름을 고정으로 변경
현재 primary 구조에서는 organization별 bucket을 생성하고 (현재상황) organization은 계정과 같은 개념이므로 고정명으로 사용가능
추후 organization을 논리적 개념으로 가져가면서 하나의 계정에 여러개 생성가능하도록 하면 이에 대한 수정이 필요한데 현재 organization을 전달하므로 그냥 사용하면 될듯