### PR TITLE
use AWS managed policy for EBS CSI

### DIFF
--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -13,7 +13,6 @@ global:
   mdMaxSizePerAz: CHANGEME
   mdMachineType: CHANGEME
   cpReplicas: CHANGEME
-  awsAccountID: CHANGEME
   cloudAccountID: CHANGEME
 charts:
 - name: cluster-api-aws

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -13,7 +13,6 @@ global:
   mdMaxSizePerAz: CHANGEME
   mdMachineType: CHANGEME
   cpReplicas: CHANGEME
-  awsAccountID: CHANGEME
   cloudAccountID: CHANGEME
 charts:
 - name: cluster-api-aws
@@ -27,7 +26,6 @@ charts:
       - name: "aws-ebs-csi-driver"
         version: "v1.15.0-eksbuild.1"
         conflictResolution: "overwrite"
-        serviceAccountRoleARN: arn:aws:iam::$(awsAccountID):role/AmazonEKS_EBS_CSI_DriverRole_$(clusterName)
       - name: "vpc-cni"
         version: "v1.10.1-eksbuild.1"
         conflictResolution: "overwrite"


### PR DESCRIPTION
EBS CSI를 위한 권한을 별도 생성한 내역을 사용하는 대신 AWS 에서 관리하는 정책 (arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy) 을 사용하도록 변경합니다.