### PR TITLE
eks: k8s v1.25 지원, eks-msa-reference 사이트 추가

### DIFF
--- a/eks-msa-reference/lma/kustomization.yaml
+++ b/eks-msa-reference/lma/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../base
+
+transformers:
+  - site-values.yaml

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -1,0 +1,251 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: site
+
+global:
+  nodeSelector:
+    taco-lma: enabled
+  clusterName: cluster.local
+  storageClassName: taco-storage
+  repository: https://openinfradev.github.io/helm-repo/
+  serviceScrapeInterval: 30s
+  defaultPassword: password
+  defaultUser: taco
+  thanosObjstoreSecret: taco-objstore-secret
+  thanosPrimaryCluster: false
+
+  lokiHost: loki-loki-distributed-gateway
+  lokiPort: 80
+  s3Host: minio.lma.svc
+  s3Port: 9000
+
+  grafanaDatasourceMetric: lma-prometheus.lma:9090
+  thanosQueryStores:
+  - thanos-storegateway:10901
+  - prometheus-operated:10901
+
+  # servicemesh dashboard and grafana
+  realms: 04a70f29
+  serviceDomain: taco-cat.xyz
+  keycloakDomain: keycloak-eom.taco-cat.xyz
+  grafanaClientSecret: JLtsanYtrCg21RGxrcVmQP0GeuDFUhpA
+
+charts:
+- name: prometheus-operator
+  override:
+    prometheusOperator.nodeSelector: $(nodeSelector)
+    prometheusOperator.admissionWebhooks.patch.image.sha: ""
+
+- name: prometheus
+  override:
+    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
+    prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 20Gi
+    prometheus.prometheusSpec.retention: 2d
+    prometheus.prometheusSpec.externalLabels.taco_cluster: $(clusterName)
+    prometheus.prometheusSpec.nodeSelector: $(nodeSelector)
+
+    alertmanager.service.type: NodePort
+    alertmanager.service.nodePort: 30111
+    alertmanager.alertmanagerSpec.alertmanagerConfigSelector.matchLabels.alertmanagerConfig: example
+    alertmanager.alertmanagerSpec.nodeSelector: $(nodeSelector)
+    alertmanager.alertmanagerSpec.retention: 2h
+    alertmanager.config.global.slack_api_url: https://hooks.slack.com/services/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
+
+- name: prometheus-node-exporter
+  override:
+    hostNetwork: false
+
+- name: kube-state-metrics
+  override:
+    nodeSelector: $(nodeSelector)
+
+- name: prometheus-pushgateway
+  override:
+    nodeSelector: $(nodeSelector)
+
+- name: prometheus-process-exporter
+  override:
+    conf.processes: dockerd,kubelet,kube-proxy,ntpd,node
+    pod.hostNetwork: false
+
+- name: grafana
+  override:
+    adminPassword: password
+    persistence.storageClassName: $(storageClassName)
+    sidecar.dashboards.searchNamespace: ALL
+    # grafana oidc
+    service.type: ClusterIP
+    grafana.ini.server:
+      domain: dashboard-$(realms).$(serviceDomain)
+      root_url: https://dashboard-$(realms).$(serviceDomain)/grafana
+      serve_from_sub_path: true
+    grafana.ini.auth.generic_oauth:
+      enabled: true
+      name: keycloak
+      allow_sign_up: true
+      client_id: grafana
+      client_secret: $(grafanaClientSecret)
+      scopes: openid profile email
+      auth_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/auth
+      token_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/token
+      api_url: https://$(keycloakDomain)/auth/realms/$(realms)/protocol/openid-connect/userinfo
+    grafana.ini.auth:
+      disable_login_form: false
+      oauth_auto_login: true
+      disable_signout_menu: true
+    grafana.ini.security:
+      allow_embedding: true
+      cookie_secure: true
+      cookie_samesite: none
+    grafana.ini.user:
+      auto_assign_org: true
+      auto_assign_org_role: Admin
+
+- name: fluent-operator
+
+- name: fluentbit
+  override:
+    fluentbit:
+      clusterName: $(clusterName)
+      outputs:
+        loki:
+        - name: taco-loki
+          host: $(lokiHost)
+          port: $(lokiPort)
+      targetLogs:
+      - tag: kube.*
+        bufferChunkSize: 2M
+        bufferMaxSize: 5M
+        do_not_store_as_default: false
+        index: container
+        loki_name: taco-loki
+        memBufLimit: 20MB
+        multi_index:
+        - index: platform
+          loki_name: taco-loki
+          key: $kubernetes['namespace_name']
+          value: kube-system|taco-system|lma|argo
+        parser: docker
+        path: /var/log/containers/*.log
+        type: kubernates
+        extraArgs:
+          multilineParser: docker, cri
+      - tag: syslog.*
+        loki_name: taco-loki
+        index: syslog
+        parser: taco-syslog-parser-for-ubuntu
+        path: /var/log/syslog
+        type: syslog
+
+- name: addons
+  override:
+    SPECIAL_VALUE: SPECIAL
+    serviceMonitor.trident:
+      enabled: false
+      interval: $(serviceScrapeInterval)
+    serviceMonitor.kubelet.interval: 30s
+    serviceMonitor.additionalScrapeConfigs:
+    grafanaDashboard.istio.enabled: false
+    grafanaDashboard.jaeger.enabled: false
+    serviceMonitor.istio.enabled: false
+    serviceMonitor.jaeger.enabled: false
+    prometheusRules.istio.aggregation.enabled: false
+    prometheusRules.istio.optimization.enabled: false
+    grafanaDatasource.prometheus.url: $(grafanaDatasourceMetric)
+    # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
+    grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
+
+- name: prometheus-adapter
+  override:
+    nodeSelector: $(nodeSelector)
+
+- name: kubernetes-event-exporter
+  override:
+    clustername: $(clusterName)
+
+    conf.recievers:
+      - name: loki
+        type: file
+        config:
+          path: "/tmp/kubernetes-event.log"
+    addons:
+      loki:
+        enabled: true
+        host: $(lokiHost)
+        port: $(lokiPort)
+        target_file: "/tmp/kubernetes-event.log"
+    conf.default.hosts:
+    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+
+- name: minio
+  override:
+    users:
+      - accessKey: $(defaultUser)
+        secretKey: $(defaultPassword)
+        policy: consoleAdmin
+    buckets:
+      - name: thanos
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
+      - name: loki
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
+    persistence.storageClass: $(storageClassName)
+    persistence.size: 3000Gi
+    persistence.accessMode: ReadWriteOnce
+    service.type: LoadBalancer
+
+- name: thanos
+  override:
+    global.storageClass: $(storageClassName)
+    # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
+    # clusterDomain: $(clusterName)
+    existingObjstoreSecret: $(thanosObjstoreSecret)
+    query.nodeSelector: $(nodeSelector)
+    queryFrontend.nodeSelector: $(nodeSelector)
+    queryFrontend.service.type: NodePort
+    queryFrontend.service.http.nodePort: 30007
+    querier.stores: $(thanosQueryStores)
+    bucketweb.nodeSelector: $(nodeSelector)
+    compactor.nodeSelector: $(nodeSelector)
+    storegateway.nodeSelector: $(nodeSelector)
+    compactor.persistence.size: 8Gi
+    # compactor.extraFlags:
+    # - --compact.enable-vertical-compaction
+    # - --deduplication.replica-label="replica"
+    storegateway.persistence.size: 8Gi
+    ruler.nodeSelector: $(nodeSelector)
+    ruler.alertmanagers:
+    - http://alertmanager-operated:9093
+    ruler.persistence.size: 8Gi
+
+- name: thanos-config
+  override:
+    objectStorage:
+      bucketName: thanos
+      endpoint: $(s3Host):$(s3Port)
+      access_key: $(defaultUser)
+      secret_key: $(defaultPassword)
+      secretName: $(thanosObjstoreSecret)
+    sidecarsService.name: thanos-sidecars
+    sidecarsService.endpoints:
+      - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)
+
+- name: prepare-etcd-secret
+  override:
+    nodeSelector:
+      "node-role.kubernetes.io/master": ""
+    tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+        operator: "Exists"
+
+- name: loki
+  override:
+    global.dnsService: kube-dns
+    gateway.service.type: LoadBalancer

--- a/eks-msa-reference/service-mesh/kustomization.yaml
+++ b/eks-msa-reference/service-mesh/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../base
+    
+transformers:
+  - site-values.yaml

--- a/eks-msa-reference/service-mesh/site-values.yaml
+++ b/eks-msa-reference/service-mesh/site-values.yaml
@@ -1,0 +1,178 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: site
+
+global:
+  clusterName: cluster.local
+  namespace: tks-msa
+  imageRepo: harbor-cicd.taco-cat.xyz/tks
+  serviceMeshControlNodeSelector:
+    tks-msa: enabled
+  serviceMeshIngressNodeSelector:
+    tks-ingressgateway: enabled
+  serviceMeshEgressNodeSelector:
+    tks-egressgateway: enabled
+  ingressGatewayLabel: istio-ingressgateway
+  egressGatewayLabel: istio-egressgateway
+
+charts:
+- name: cert-manager
+  override: {}
+
+- name: k8ssandra-operator
+  override: {}
+
+- name: servicemesh-k8ssandra-resource
+  override:
+    namespace: $(namespace)
+    cassandra:
+      datacenters:
+        size: 2
+        config:
+          heapSize: 2048M
+        storageConfig:
+          storageClassName: taco-storage
+          accessModes: ReadWriteOnce
+          size: 300Gi
+        racks:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tks-msa
+                    operator: In
+                    values:
+                    - enabled
+        stargate:
+          size: 1
+          heapSize: 384M
+          nodeSelector:
+            tks-msa: enabled
+
+- name: istiod
+  override:
+    revision: ""
+    pilot.autoscaleEnabled: false
+    pilot.traceSampling: 1.0
+    pilot.nodeSelector: $(serviceMeshControlNodeSelector)
+    global.proxy.clusterDomain: $(clusterName)
+    global.tracer.zipkin.address: jaeger-operator-jaeger-collector.$(namespace):9411
+
+- name: istio-ingressgateway
+  override:
+    revision: ""
+    replicaCount: 2
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+    service.type: LoadBalancer
+    resources.requests.cpu: 1000m
+    resources.requests.memory: 1024Mi
+    resources.limits.cpu: 2000m
+    resources.limits.memory: 2048Mi
+    nodeSelector: $(serviceMeshIngressNodeSelector)
+
+- name: istio-egressgateway
+  override:
+    revision: ""
+    replicaCount: 1
+    autoscaling.enabled: false
+    service.type: ClusterIP
+    resources.requests.cpu: 1000m
+    resources.requests.memory: 1024Mi
+    resources.limits.cpu: 2000m
+    resources.limits.memory: 2048Mi
+    nodeSelector: $(serviceMeshEgressNodeSelector)
+
+- name: jaeger-operator
+  override:
+    nodeSelector: $(serviceMeshControlNodeSelector)
+
+- name: servicemesh-jaeger-resource
+  override:
+    namespace: tks-msa
+    sampling.param: 100
+    collector.resources.requests.cpu: 500m
+    collector.resources.requests.memory: 1024Mi
+    collector.resources.limits.cpu: 1000m
+    collector.resources.limits.memory: 2048Mi
+    collector:
+      image: harbor-cicd.taco-cat.xyz/tks/jaeger-collector:1.35.0
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tks-msa
+                operator: In
+                values:
+                - enabled
+    storage:
+      type: cassandra
+      cassandra:
+        options:
+          servers: cassandra-dc-service.tks-msa.svc
+          keyspace: jaeger_v1_datacenter
+        dependencies:
+          enabled: true
+          image: harbor-cicd.taco-cat.xyz/tks/spark-dependencies:1.35.0
+    query:
+      image: harbor-cicd.taco-cat.xyz/tks/jaeger-query:1.35.0
+      basePath: /
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tks-msa
+                operator: In
+                values:
+                - enabled
+    agent:
+      image: harbor-cicd.taco-cat.xyz/tks/jaeger-agent:1.35.0
+    cassandra:
+      user:
+        enabled: true
+        username: tks
+        password: tksword
+      nodeSelector:
+        tks-msa: enabled
+    elasticsearch.user.enabled: false
+
+- name: kiali-operator
+  override:
+    image:
+      repo: harbor-cicd.taco-cat.xyz/tks/kiali-operator
+      tag: v1.63.0
+    nodeSelector: $(serviceMeshControlNodeSelector)
+
+- name: servicemesh-kiali-resource
+  override:
+    namespace: tks-msa
+    istioNamespace: tks-msa
+    deployment.namespace: tks-msa
+    deployment.image_name: harbor-cicd.taco-cat.xyz/tks/kiali
+    deployment.image_version: v1.63.0
+    deployment.resources.requests.cpu: 500m
+    deployment.resources.requests.memory: 512Mi
+    deployment.resources.limits.cpu: 1000m
+    deployment.resources.limits.memory: 1024Mi
+    deployment.nodeSelector:
+      tks-msa: enabled
+    auth.strategy: anonymous
+    externalServices.istio.configMapName: istio
+    externalServices.istio.istioIdentityDomain: svc.$(clusterName)
+    externalServices.prometheus.url: http://lma-prometheus.lma.svc:9090
+    externalServices.tracing.inClusterUrl: http://jaeger-operator-jaeger-query.tks-msa:16686
+    externalServices.tracing.url: https://jaeger-v2.taco-cat.xyz
+    externalServices.tracing.useGrpc: false
+    externalServices.grafana.auth.type: basic
+    externalServices.grafana.auth.username: admin
+    externalServices.grafana.auth.password: password
+    externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
+    externalServices.grafana.url: https://grafana-v2.taco-cat.xyz
+    server.webRoot: /

--- a/eks-msa-reference/tks-cluster/kustomization.yaml
+++ b/eks-msa-reference/tks-cluster/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../base
+- ../infra/aws
+
+transformers:
+- site-values.yaml

--- a/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/eks-msa-reference/tks-cluster/site-values.yaml
@@ -1,0 +1,89 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: site
+
+global:
+  # These values are replaced on cluster creation by workflow
+  clusterName: cluster.local
+  sshKeyName: CHANGEME
+  clusterRegion: CHANGEME
+  mdNumOfAz: CHANGEME
+  mdMinSizePerAz: CHANGEME
+  mdMaxSizePerAz: CHANGEME
+  mdMachineType: CHANGEME
+  cpReplicas: CHANGEME
+  mpReplicas: CHANGEME
+  mpMachineType: CHANGEME
+  cloudAccountID: CHANGEME
+charts:
+- name: cluster-api-aws
+  override:
+    sshKeyName: $(sshKeyName)
+    cluster:
+      name: $(clusterName)
+      region: $(clusterRegion)
+      eksEnabled: true
+      kubernetesVersion: v1.25.9
+      eksAddons:
+      - name: "aws-ebs-csi-driver"
+        version: "v1.18.0-eksbuild.1"
+        conflictResolution: "overwrite"
+      - name: "vpc-cni"
+        conflictResolution: "overwrite"
+        version: "v1.12.6-eksbuild.2"
+      multitenancyId:
+        kind: AWSClusterRoleIdentity
+        name: $(cloudAccountID)-account-role
+      bastion.enabled: false
+    machinePool:
+    - name: taco
+      machineType: $(mpMachineType)
+      replicas: $(mpReplicas)
+      minSize: 1
+      maxSize: 16
+      rootVolume:
+        size: 200
+        type: gp2
+      labels:
+        taco-lma: enabled
+        servicemesh: enabled
+        taco-ingress-gateway: enabled
+    - name: normal
+      machineType: $(mdMachineType)
+      replicas: $(mdNumOfAz)
+      minSize: $(mdMinSizePerAz)
+      maxSize: $(mdMaxSizePerAz)
+      rootVolume:
+        size: 50
+        type: gp2
+
+- name: ingress-nginx
+  override:
+    controller:
+      nodeSelector:
+        taco-lma: enabled
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+      service:
+        externalTrafficPolicy: Local
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-name: "taco-ingress-nlb"
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+        type: LoadBalancer
+      config:
+        enable-underscores-in-headers: "true"
+        proxy-body-size: "10m"
+
+- name: cluster-autoscaler
+  override:
+    discoveryNamespace: $(clusterName)
+    discoveryClusterName: $(clusterName)
+
+- name: cluster-autoscaler-rbac
+  override:
+    deployMgmtRbacOnly:
+      targetNamespace: $(clusterName)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -14,6 +14,17 @@ global:
   defaultUser: taco
   thanosObjstoreSecret: taco-objstore-secret
   thanosPrimaryCluster: false
+
+  lokiHost: loki-loki-distributed-gateway
+  lokiPort: 80
+  s3Host: minio.lma.svc
+  s3Port: 9000
+
+  grafanaDatasourceMetric: lma-prometheus.lma:9090
+  thanosQueryStores:
+  - thanos-storegateway:10901
+  - prometheus-operated:10901
+
   # servicemesh dashboard and grafana
   realms: 04a70f29
   serviceDomain: taco-cat.xyz
@@ -100,8 +111,8 @@ charts:
       outputs:
         loki:
         - name: taco-loki
-          host: loki-loki-distributed-gateway
-          port: 80
+          host: $(lokiHost)
+          port: $(lokiPort)
       targetLogs:
       - tag: kube.*
         bufferChunkSize: 2M
@@ -141,6 +152,9 @@ charts:
     serviceMonitor.jaeger.enabled: false
     prometheusRules.istio.aggregation.enabled: false
     prometheusRules.istio.optimization.enabled: false
+    grafanaDatasource.prometheus.url: $(grafanaDatasourceMetric)
+    # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
+    grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 
 - name: prometheus-adapter
   override:
@@ -148,6 +162,8 @@ charts:
 
 - name: kubernetes-event-exporter
   override:
+    clustername: $(clusterName)
+
     conf.recievers:
       - name: loki
         type: file
@@ -156,27 +172,46 @@ charts:
     addons:
       loki:
         enabled: true
-        host: loki
-        port: 3100
+        host: $(lokiHost)
+        port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
-
     conf.default.hosts:
     - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+
+- name: minio
+  override:
+    users:
+      - accessKey: $(defaultUser)
+        secretKey: $(defaultPassword)
+        policy: consoleAdmin
+    buckets:
+      - name: thanos
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
+      - name: loki
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
+    persistence.storageClass: $(storageClassName)
+    persistence.size: 3000Gi
+    persistence.accessMode: ReadWriteOnce
+    service.type: LoadBalancer
 
 - name: thanos
   override:
     global.storageClass: $(storageClassName)
-    clusterDomain: $(clusterName)
+    # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
+    # clusterDomain: $(clusterName)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     queryFrontend.nodeSelector: $(nodeSelector)
     queryFrontend.service.type: NodePort
     queryFrontend.service.http.nodePort: 30007
-    querier.stores:
-    - prometheus-operated.lma.svc.$(clusterName):10901
-    bucketweb.enabled: $(thanosPrimaryCluster)
+    querier.stores: $(thanosQueryStores)
     bucketweb.nodeSelector: $(nodeSelector)
-    compactor.enabled: $(thanosPrimaryCluster)
     compactor.nodeSelector: $(nodeSelector)
     storegateway.nodeSelector: $(nodeSelector)
     compactor.persistence.size: 8Gi
@@ -184,23 +219,16 @@ charts:
     # - --compact.enable-vertical-compaction
     # - --deduplication.replica-label="replica"
     storegateway.persistence.size: 8Gi
-    ruler.enabled: $(thanosPrimaryCluster)
     ruler.nodeSelector: $(nodeSelector)
     ruler.alertmanagers:
-    - http://fed-master-alertmanager.lma.svc.$(clusterName):9093
+    - http://alertmanager-operated:9093
     ruler.persistence.size: 8Gi
-    minio.accessKey.password: $(defaultUser)
-    minio.secretKey.password: $(defaultPassword)
-    minio.defaultBuckets: thanos
-    minio.persistence.storageClass: $(storageClassName)
-    minio.persistence.accessMode: ReadWriteOnce
-    minio.persistence.size: 10Gi
 
 - name: thanos-config
   override:
     objectStorage:
       bucketName: thanos
-      endpoint: minio.lma.svc.$(clusterName):9000
+      endpoint: $(s3Host):$(s3Port)
       access_key: $(defaultUser)
       secret_key: $(defaultPassword)
       secretName: $(thanosObjstoreSecret)
@@ -220,3 +248,4 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
+    gateway.service.type: LoadBalancer

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -13,6 +13,8 @@ global:
   mdMaxSizePerAz: CHANGEME
   mdMachineType: CHANGEME
   cpReplicas: CHANGEME
+  mpReplicas: CHANGEME
+  mpMachineType: CHANGEME
   cloudAccountID: CHANGEME
 charts:
 - name: cluster-api-aws
@@ -22,21 +24,22 @@ charts:
       name: $(clusterName)
       region: $(clusterRegion)
       eksEnabled: true
+      kubernetesVersion: v1.25.9
       eksAddons:
       - name: "aws-ebs-csi-driver"
-        version: "v1.15.0-eksbuild.1"
+        version: "v1.18.0-eksbuild.1"
         conflictResolution: "overwrite"
       - name: "vpc-cni"
-        version: "v1.10.1-eksbuild.1"
         conflictResolution: "overwrite"
+        version: "v1.12.6-eksbuild.2"
       multitenancyId:
         kind: AWSClusterRoleIdentity
         name: $(cloudAccountID)-account-role
       bastion.enabled: false
     machinePool:
     - name: taco
-      machineType: t3.2xlarge
-      replicas: 3
+      machineType: $(mpMachineType)
+      replicas: $(mpReplicas)
       minSize: 1
       maxSize: 16
       rootVolume:
@@ -46,14 +49,11 @@ charts:
         taco-lma: enabled
         servicemesh: enabled
         taco-ingress-gateway: enabled
-    machineDeployment:
     - name: normal
-      numberOfAZ: $(mdNumOfAz)
-      minSizePerAZ: $(mdMinSizePerAz)
-      maxSizePerAZ: $(mdMaxSizePerAz)
-      selector:
-        matchLabels:
       machineType: $(mdMachineType)
+      replicas: $(mdNumOfAz)
+      minSize: $(mdMinSizePerAz)
+      maxSize: $(mdMaxSizePerAz)
       rootVolume:
         size: 50
         type: gp2


### PR DESCRIPTION
- eks 버전을 v1.25 로 업데이트 
- eks-reference 의 lma 사이트 변수를 aws-msa-reference 값과 동기화
-  eks-msa-reference 사이트 추가 (aws-msa-reference의 lma, service-mesh 기준)