### PR TITLE
kube-state-metrics: add kube version not to use psp

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -59,6 +59,7 @@ charts:
 - name: kube-state-metrics
   override:
     nodeSelector: $(nodeSelector)
+    kubeVersion: v1.25.7
 
 - name: prometheus-pushgateway
   override:

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -59,6 +59,7 @@ charts:
 - name: kube-state-metrics
   override:
     nodeSelector: $(nodeSelector)
+    kubeVersion: v1.25.7
 
 - name: prometheus-pushgateway
   override:


### PR DESCRIPTION
rendering을 먼저하는 decapod특성상 구동 버전을 알수 없어서 수동으로 kubernetes 버전을 지정해야 함.