### PR TITLE
eks-*-reference: add cluster-autoscaler

### DIFF
--- a/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/eks-msa-reference/tks-cluster/site-values.yaml
@@ -87,3 +87,11 @@ charts:
   override:
     deployMgmtRbacOnly:
       targetNamespace: $(clusterName)
+
+- name: k8s-cluster-autoscaler
+  override:
+    image:
+      tag: v1.25.1
+    awsRegion: ap-northeast-2
+    autoDiscovery:
+      clusterName: $(clusterName)

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -87,3 +87,11 @@ charts:
   override:
     deployMgmtRbacOnly:
       targetNamespace: $(clusterName)
+
+- name: k8s-cluster-autoscaler
+  override:
+    image:
+      tag: v1.25.1
+    awsRegion: ap-northeast-2
+    autoDiscovery:
+      clusterName: $(clusterName)


### PR DESCRIPTION
EKS 에서 노드 오토스케일링을 위한 cluster-autoscaler 차트를 추가합니다.
- https://github.com/openinfradev/decapod-base-yaml/pull/227