### PR TITLE
tks-cluser: make taco node's min. and max. replicas to 3

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -50,8 +50,8 @@ charts:
     - name: taco
       machineType: $(mpMachineType)
       replicas: $(mpReplicas)
-      minSize: 1
-      maxSize: 16
+      minSize: 3
+      maxSize: 3
       rootVolume:
         size: 200
         type: gp2

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -13,6 +13,9 @@ global:
   mdMaxSizePerAz: CHANGEME
   mdMachineType: CHANGEME
   cpReplicas: CHANGEME
+  mpReplicas: CHANGEME
+  mpMachineType: CHANGEME
+  awsAccountID: CHANGEME
   cloudAccountID: CHANGEME
 charts:
 - name: cluster-api-aws
@@ -45,10 +48,10 @@ charts:
       replicas: $(cpReplicas)
     machinePool:
     - name: taco
-      machineType: t3.2xlarge
-      replicas: 3
-      minSize: 1
-      maxSize: 16
+      machineType: $(mpMachineType)
+      replicas: $(mpReplicas)
+      minSize: 3
+      maxSize: 3
       rootVolume:
         size: 200
         type: gp2

--- a/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/eks-msa-reference/tks-cluster/site-values.yaml
@@ -40,8 +40,8 @@ charts:
     - name: taco
       machineType: $(mpMachineType)
       replicas: $(mpReplicas)
-      minSize: 1
-      maxSize: 16
+      minSize: 3
+      maxSize: 3
       rootVolume:
         size: 200
         type: gp2

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -40,8 +40,8 @@ charts:
     - name: taco
       machineType: $(mpMachineType)
       replicas: $(mpReplicas)
-      minSize: 1
-      maxSize: 16
+      minSize: 3
+      maxSize: 3
       rootVolume:
         size: 200
         type: gp2


### PR DESCRIPTION
taco 노드의 min, max 리플리카 수를 3으로 고정합니다. cluster-autoscaler 사용 시 이전 min 값인 1로 변화하는 경우가 있고 3 노드에서 변동은 없을 것으로 생각합니다.