### PR TITLE
loki: explicitly define storage class name

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -328,3 +328,8 @@ charts:
   override:
     global.dnsService: kube-dns
     gateway.service.type: LoadBalancer
+    ingester.persistence.storageClass: $(storageClassName)
+    distributor.persistence.storageClass: $(storageClassName)
+    queryFrontend.persistence.storageClass: $(storageClassName)
+    ruler.persistence.storageClass: $(storageClassName)
+    indexGateway.persistence.storageClass: $(storageClassName)

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -327,3 +327,8 @@ charts:
   override:
     global.dnsService: kube-dns
     gateway.service.type: LoadBalancer
+    ingester.persistence.storageClass: $(storageClassName)
+    distributor.persistence.storageClass: $(storageClassName)
+    queryFrontend.persistence.storageClass: $(storageClassName)
+    ruler.persistence.storageClass: $(storageClassName)
+    indexGateway.persistence.storageClass: $(storageClassName)

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -330,3 +330,8 @@ charts:
   override:
     global.dnsService: kube-dns
     gateway.service.type: LoadBalancer
+    ingester.persistence.storageClass: $(storageClassName)
+    distributor.persistence.storageClass: $(storageClassName)
+    queryFrontend.persistence.storageClass: $(storageClassName)
+    ruler.persistence.storageClass: $(storageClassName)
+    indexGateway.persistence.storageClass: $(storageClassName)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -329,3 +329,8 @@ charts:
   override:
     global.dnsService: kube-dns
     gateway.service.type: LoadBalancer
+    ingester.persistence.storageClass: $(storageClassName)
+    distributor.persistence.storageClass: $(storageClassName)
+    queryFrontend.persistence.storageClass: $(storageClassName)
+    ruler.persistence.storageClass: $(storageClassName)
+    indexGateway.persistence.storageClass: $(storageClassName)


### PR DESCRIPTION
loki에서 생성하는 disk가 default가 아닌 명시적으로 지정한 것을 사용하도록 변경합니다.
