### PR TITLE
minio: reduce default storage size

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -222,7 +222,7 @@ charts:
         versioning: true
         objectlocking: false
     persistence.storageClass: $(storageClassName)
-    persistence.size: 3000Gi
+    persistence.size: 500Gi
     persistence.accessMode: ReadWriteOnce
     service.type: LoadBalancer
     service.annotations: $(awsNlbAnnotation)

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -222,7 +222,7 @@ charts:
         versioning: true
         objectlocking: false
     persistence.storageClass: $(storageClassName)
-    persistence.size: 3000Gi
+    persistence.size: 500Gi
     persistence.accessMode: ReadWriteOnce
     service.type: LoadBalancer
     service.annotations: $(awsNlbAnnotation)

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -227,7 +227,7 @@ charts:
         versioning: true
         objectlocking: false
     persistence.storageClass: $(storageClassName)
-    persistence.size: 3000Gi
+    persistence.size: 500Gi
     persistence.accessMode: ReadWriteOnce
     service.type: LoadBalancer
     service.annotations: $(awsNlbAnnotation)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -223,7 +223,7 @@ charts:
         versioning: true
         objectlocking: false
     persistence.storageClass: $(storageClassName)
-    persistence.size: 3000Gi
+    persistence.size: 500Gi
     persistence.accessMode: ReadWriteOnce
     service.type: LoadBalancer
     service.annotations: $(awsNlbAnnotation)


### PR DESCRIPTION
minio에 올라가는 객체에 대한 ilm을 추가함에 따라 과도한 디스크를 할당했었던 부분을 수정합니다.

- from: 3TB
- to: 500GB