### PR TITLE
ack-resources: add controllerability for versioned objects on s3 buckets

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -397,5 +397,7 @@ charts:
     s3.enabled: true
     s3.buckets:
     - name: $(clusterName)-tks-thanos
+      versioning: Disabled
     - name: $(clusterName)-tks-loki
+      versioning: Disabled
     tks.iamRoles: $(tksIamRoles)

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -397,5 +397,7 @@ charts:
     s3.enabled: true
     s3.buckets:
     - name: $(clusterName)-tks-thanos
+      versioning: Disabled
     - name: $(clusterName)-tks-loki
+      versioning: Disabled
     tks.iamRoles: $(tksIamRoles)

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -398,5 +398,7 @@ charts:
     s3.enabled: true
     s3.buckets:
     - name: $(clusterName)-tks-thanos
+      versioning: Disabled
     - name: $(clusterName)-tks-loki
+      versioning: Disabled
     tks.iamRoles: $(tksIamRoles)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -398,5 +398,7 @@ charts:
     s3.enabled: true
     s3.buckets:
     - name: $(clusterName)-tks-thanos
+      versioning: Disabled
     - name: $(clusterName)-tks-loki
+      versioning: Disabled
     tks.iamRoles: $(tksIamRoles)


### PR DESCRIPTION
버킷이 비워지지 않아서 클러스터가 삭제되지 않는 버그에 대한 수정입니다.
다음 내역이 한꺼번에 merge되어야 합니다.
- https://github.com/openinfradev/helm-charts/pull/194
- https://github.com/openinfradev/decapod-base-yaml/pull/252
- https://github.com/openinfradev/decapod-site/pull/166