### PR TITLE
bugfix: change syslog location from ubuntu type to centos type for ek…

### DIFF
--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -171,7 +171,7 @@ charts:
         loki_name: taco-loki
         index: syslog
         parser: taco-syslog-parser-for-ubuntu
-        path: /var/log/syslog
+        path: /var/log/messages
         type: syslog
 
 - name: addons

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -171,7 +171,7 @@ charts:
         loki_name: taco-loki
         index: syslog
         parser: taco-syslog-parser-for-ubuntu
-        path: /var/log/syslog
+        path: /var/log/messages
         type: syslog
 
 - name: addons


### PR DESCRIPTION
…s nodes

현재 생성되는 cluster에서 syslog를 확인할 수 없는 문제.
- syslog의 위치는 ubuntu와 centos 가 다름
- eks에서 생성하는 노드들이 amazon linux를 사용하고 이는 centos 계열임

이에따라 변경함