### PR TITLE
Clone ingress nginx

### DIFF
--- a/aws-reference/tks-admin-tools/site-values.yaml
+++ b/aws-reference/tks-admin-tools/site-values.yaml
@@ -19,7 +19,7 @@ charts:
     externalDatabase.host: $(dbHost)
     externalDatabase.password: $(commonPassword)
 
-- name: tks-api
+- name: tks-apis
   override:
     gitBaseUrl: https://github.com
     gitAccount: decapod10

--- a/aws-reference/tks-admin-tools/site-values.yaml
+++ b/aws-reference/tks-admin-tools/site-values.yaml
@@ -76,6 +76,7 @@ charts:
       external:
         host: $(dbHost)  
         password: $(commonPassword)
+        sslmode: "require"
     core:
       replicas: 2  
     jobservice:

--- a/aws-reference/tks-admin-tools/site-values.yaml
+++ b/aws-reference/tks-admin-tools/site-values.yaml
@@ -89,3 +89,17 @@ charts:
     portal:
       replicas: 2  
     harborAdminPassword: $(commonPassword)
+
+- name: ingress-nginx
+  override:
+    controller:
+      service:
+        externalTrafficPolicy: Local
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-name: "taco-ingress-nlb"
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+        type: LoadBalancer
+      config:
+        enable-underscores-in-headers: "true"
+        proxy-body-size: "10m"

--- a/byoh-reference/tks-admin-tools/site-values.yaml
+++ b/byoh-reference/tks-admin-tools/site-values.yaml
@@ -19,7 +19,7 @@ charts:
     externalDatabase.host: $(dbHost)
     externalDatabase.password: $(commonPassword)
 
-- name: tks-api
+- name: tks-apis
   override:
     gitBaseUrl: https://github.com
     gitAccount: decapod10

--- a/byoh-reference/tks-admin-tools/site-values.yaml
+++ b/byoh-reference/tks-admin-tools/site-values.yaml
@@ -89,3 +89,17 @@ charts:
     portal:
       replicas: 2  
     harborAdminPassword: $(commonPassword)
+
+- name: ingress-nginx
+  override:
+    controller:
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+      service:
+        externalTrafficPolicy: Local
+        type: NodePort
+      config:
+        enable-underscores-in-headers: "true"
+        proxy-body-size: "10m"

--- a/byoh-reference/tks-admin-tools/site-values.yaml
+++ b/byoh-reference/tks-admin-tools/site-values.yaml
@@ -76,6 +76,7 @@ charts:
       external:
         host: $(dbHost)  
         password: $(commonPassword)
+        sslmode: "require"
     core:
       replicas: 2  
     jobservice:

--- a/eks-reference/tks-admin-tools/site-values.yaml
+++ b/eks-reference/tks-admin-tools/site-values.yaml
@@ -19,7 +19,7 @@ charts:
     externalDatabase.host: $(dbHost)
     externalDatabase.password: $(commonPassword)
 
-- name: tks-api
+- name: tks-apis
   override:
     gitBaseUrl: https://github.com
     gitAccount: decapod10

--- a/eks-reference/tks-admin-tools/site-values.yaml
+++ b/eks-reference/tks-admin-tools/site-values.yaml
@@ -76,6 +76,7 @@ charts:
       external:
         host: $(dbHost)  
         password: $(commonPassword)
+        sslmode: "require"
     core:
       replicas: 2  
     jobservice:

--- a/eks-reference/tks-admin-tools/site-values.yaml
+++ b/eks-reference/tks-admin-tools/site-values.yaml
@@ -89,3 +89,17 @@ charts:
     portal:
       replicas: 2  
     harborAdminPassword: $(commonPassword)
+
+- name: ingress-nginx
+  override:
+    controller:
+      service:
+        externalTrafficPolicy: Local
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-name: "taco-ingress-nlb"
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+        type: LoadBalancer
+      config:
+        enable-underscores-in-headers: "true"
+        proxy-body-size: "10m"


### PR DESCRIPTION
ingress-ngnix 를 tks-admin-tools 그룹에 복사합니다.
nodeSelector 및 namespace 등 설정이 usercluster 배포 시와는 다르므로 별도의 entry가 필요합니다.

다음 PR도 함께 머지되어야 합니다.
https://github.com/openinfradev/decapod-base-yaml/pull/266