### PR TITLE
byoh: use dedicated byoh label selectors for each cluster

### DIFF
--- a/byoh-reference/tks-cluster/site-values.yaml
+++ b/byoh-reference/tks-cluster/site-values.yaml
@@ -12,12 +12,16 @@ charts:
     cluster:
       name: $(clusterName)
       kubernetesVersion: v1.25.11
+    kubeadmControlPlane:
+      selector:
+        matchLabels:
+          role: $(clusterName)-control-plane
     machineDeployment:
     - name: taco
       replicas: 1
       selector:
         matchLabels:
-          role: tks
+          role: $(clusterName)-tks
       labels:
         servicemesh: enabled
         taco-egress-gateway: enabled
@@ -25,12 +29,9 @@ charts:
         taco-lma: enabled
     - name: normal
       replicas: 1
-      autoscaling:
-        minSize: 1
-        maxSize: 5
       selector:
         matchLabels:
-          role: worker
+          role: $(clusterName)-worker
 
 - name: ingress-nginx
   override:


### PR DESCRIPTION
각 클러스터를 위한 byoh 레이블 형식을 다음과 같이 사용하도록 수정하였습니다.

- CLUSTER_ID-control-plane
- CLUSTER_ID-tks
- CLUSTER_ID-worker