### PR TITLE
make the upstream cluster-autoscaler chart common to all

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -28,6 +28,7 @@ charts:
     sshKeyName: $(sshKeyName)
     cluster:
       name: $(clusterName)
+      kubernetesVersion: v1.26.10
       eksEnabled: false
       multitenancyId:
         kind: AWSClusterRoleIdentity
@@ -95,8 +96,17 @@ charts:
 
 - name: cluster-autoscaler
   override:
-    discoveryNamespace: $(clusterName)
-    discoveryClusterName: $(clusterName)
+    image:
+      repository: harbor.taco-cat.xyz/tks/cluster-autoscaler
+      tag: v1.26.4
+    autoDiscovery:
+      clusterName: $(clusterName)
+      labels:
+        - namespace: $(clusterName)
+    cloudProvider: clusterapi
+    clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
+    clusterAPIKubeconfigSecret: "mgmt-kubeconfig"
+    clusterAPIMode: incluster-kubeconfig
 
 - name: cluster-autoscaler-rbac
   override:

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -28,6 +28,7 @@ charts:
     sshKeyName: $(sshKeyName)
     cluster:
       name: $(clusterName)
+      kubernetesVersion: v1.26.10
       eksEnabled: false
       multitenancyId:
         kind: AWSClusterRoleIdentity
@@ -95,8 +96,17 @@ charts:
 
 - name: cluster-autoscaler
   override:
-    discoveryNamespace: $(clusterName)
-    discoveryClusterName: $(clusterName)
+    image:
+      repository: harbor.taco-cat.xyz/tks/cluster-autoscaler
+      tag: v1.26.4
+    autoDiscovery:
+      clusterName: $(clusterName)
+      labels:
+        - namespace: $(clusterName)
+    cloudProvider: clusterapi
+    clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
+    clusterAPIKubeconfigSecret: "mgmt-kubeconfig"
+    clusterAPIMode: incluster-kubeconfig
 
 - name: cluster-autoscaler-rbac
   override:

--- a/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/eks-msa-reference/tks-cluster/site-values.yaml
@@ -83,21 +83,28 @@ charts:
         enable-underscores-in-headers: "true"
         proxy-body-size: "10m"
 
-- name: cluster-autoscaler
-  override:
-    discoveryNamespace: $(clusterName)
-    discoveryClusterName: $(clusterName)
-
 - name: cluster-autoscaler-rbac
   override:
     deployMgmtRbacOnly:
       targetNamespace: $(clusterName)
 
-- name: k8s-cluster-autoscaler
+- name: cluster-autoscaler
   override:
     image:
       repository: harbor.taco-cat.xyz/tks/cluster-autoscaler
-      tag: v1.25.2
-    awsRegion: ap-northeast-2
+      tag: v1.25.3
     autoDiscovery:
       clusterName: $(clusterName)
+    cloudProvider: aws
+    awsRegion: ap-northeast-2
+    rbac:
+     serviceAccount:
+       create: false
+       name: "cluster-autoscaler"
+    extraArgs:
+      expander: priority
+    expanderPriorities:
+      "10":
+        - .*-taco
+      "50":
+        - .*-normal

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -86,21 +86,28 @@ charts:
         enable-underscores-in-headers: "true"
         proxy-body-size: "10m"
 
-- name: cluster-autoscaler
-  override:
-    discoveryNamespace: $(clusterName)
-    discoveryClusterName: $(clusterName)
-
 - name: cluster-autoscaler-rbac
   override:
     deployMgmtRbacOnly:
       targetNamespace: $(clusterName)
 
-- name: k8s-cluster-autoscaler
+- name: cluster-autoscaler
   override:
     image:
       repository: harbor.taco-cat.xyz/tks/cluster-autoscaler
-      tag: v1.25.2
-    awsRegion: ap-northeast-2
+      tag: v1.25.3
     autoDiscovery:
       clusterName: $(clusterName)
+    cloudProvider: aws
+    awsRegion: ap-northeast-2
+    rbac:
+     serviceAccount:
+       create: false
+       name: "cluster-autoscaler"
+    extraArgs:
+      expander: priority
+    expanderPriorities:
+      "10":
+        - .*-taco
+      "50":
+        - .*-normal


### PR DESCRIPTION
**https://github.com/openinfradev/decapod-base-yaml/pull/276 과 같이 반영이 되어야 합니다.**

Mananged Control plane과 EKS 각각 분리해서 사용하던 cluster-autoscaler 차트를 업스트림 차트([https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)로](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)%EB%A1%9C) 통일합니다.

이력
Managed controle plane: cluster-api 프로바이더 지원을 위한 내역이 부족하여 업스트림과 별도로 차트를 만들어서 사용 (https://github.com/openinfradev/helm-charts/tree/main/cluster-autoscaler)
EKS: AWS 프로바이더를 사용하여 적용
최신 버전에서는 cluster-api 프로바이더를 위해 필요한 부분도 모두 포함되어 있어 업스트림 차트를 공통적으로 사용하도록 수정

차이점
- aws*-reference: K8S 버전 1.26.10, cluster-autoscaler 버전 1.26.4
- eks*-reference: K8S 버전 1.25.9, cluster-autoscaler 버전 1.25.3
