### PR TITLE
fix cloud kubeconfig path for cluster-autoscaler

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -104,7 +104,7 @@ charts:
       labels:
         - namespace: $(clusterName)
     cloudProvider: clusterapi
-    clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
+    clusterAPICloudConfigPath: /etc/kubernetes/kubeconfig
     clusterAPIKubeconfigSecret: "mgmt-kubeconfig"
     clusterAPIMode: incluster-kubeconfig
 

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -104,7 +104,7 @@ charts:
       labels:
         - namespace: $(clusterName)
     cloudProvider: clusterapi
-    clusterAPICloudConfigPath: /etc/kubernetes/mgmt-kubeconfig
+    clusterAPICloudConfigPath: /etc/kubernetes/kubeconfig
     clusterAPIKubeconfigSecret: "mgmt-kubeconfig"
     clusterAPIMode: incluster-kubeconfig
 


### PR DESCRIPTION
cluster-autoscaler 에서 참조하는 어드민 클러스터의 kubeconfig 파일 경로가 잘못되어 있어 수정합니다.