### PR TITLE
lma: fix thanos storegateway permissions for S3

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -348,6 +348,7 @@ charts:
         access_key: $(defaultUser)
         secret_key: $(defaultPassword)
         insecure: true
+        aws_sdk_auth: true
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints:
       - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -348,6 +348,7 @@ charts:
         access_key: $(defaultUser)
         secret_key: $(defaultPassword)
         insecure: true
+        aws_sdk_auth: true
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints:
       - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -349,6 +349,7 @@ charts:
         access_key: $(defaultUser)
         secret_key: $(defaultPassword)
         insecure: true
+        aws_sdk_auth: true
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints:
       - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -349,6 +349,7 @@ charts:
         access_key: $(defaultUser)
         secret_key: $(defaultPassword)
         insecure: true
+        aws_sdk_auth: true
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints:
       - 192.168.97.102 # should not be in the loopback range (127.0.0.0/8)


### PR DESCRIPTION
thanos-storegateway 에서 S3 접근 권한 이슈를 수정합니다.

EKS 환경에서는 발생한 적이 없으나 업스트림 이슈를 보면 EKS에서도 발생할 가능성이 있어 모든 사이트에 대해 값을 수정하였습니다. Thanos 관련 문서를 봐도 AWS 인증 방식을 사용하기 위해서는 true로 설정하는 것이 맞아 보입니다.

참고:
- https://github.com/thanos-io/thanos/issues/5929#issuecomment-1600459874
- https://github.com/thanos-io/thanos/blob/main/docs/storage.md
> However if you set aws_sdk_auth: true Thanos will use the default authentication methods of the AWS SDK for go based on [known environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) (AWS_PROFILE, AWS_WEB_IDENTITY_TOKEN_FILE ... etc) and known AWS config files (~/.aws/config). If you turn this on, then the bucket and endpoint are the required config keys.