### PR TITLE
aws*-reference: use ubuntu-22.04 for base OS

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -50,6 +50,7 @@ charts:
             fromPort: 5473
             toPort: 5473
       bastion.enabled: false
+      baseOS: ubuntu-22.04
     kubeadmControlPlane:
       replicas: $(tksCpNode)
     machinePool:

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -50,6 +50,7 @@ charts:
             fromPort: 5473
             toPort: 5473
       bastion.enabled: false
+      baseOS: ubuntu-22.04
     kubeadmControlPlane:
       replicas: $(tksCpNode)
     machinePool:


### PR DESCRIPTION
aws*-reference 환경에서 사용하는 기본 OS를 Ubuntu 22.04로 변경합니다. 현재까지는 별도 설정 없이 기본 값인 Ubuntu 18.04가 사용되었었습니다.