### PR TITLE
fix aws*-reference for production

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -10,9 +10,8 @@ global:
   clusterRegion: CHANGEME
   cloudAccountID: CHANGEME
 
-  tksCpNode: CHNAGEME
-  tksCpNodeMax: CHANGEME
-  tksCpNodeType: CHANGEME
+  tksCpNode: 3
+  tksCpNodeType: m5a.2xlarge
   tksInfraNode: CHNAGEME
   tksInfraNodeMax: CHANGEME
   tksInfraNodeType: CHANGEME
@@ -49,10 +48,12 @@ charts:
             protocol: tcp
             fromPort: 5473
             toPort: 5473
-      bastion.enabled: false
-      baseOS: ubuntu-22.04
+      bastion:
+        enabled: false
+      baseOS: ubuntu-20.04
     kubeadmControlPlane:
       replicas: $(tksCpNode)
+      controlPlaneMachineType: $(tksCpNodeType)
     machinePool:
     - name: taco
       machineType: $(tksInfraNodeType)
@@ -68,16 +69,17 @@ charts:
         taco-ingress-gateway: enabled
       roleAdditionalPolicies:
       - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+    machineDeployment:
     - name: normal
+      numberOfAZ: 3 # ap-northeast-2
+      minSizePerAZ: $(tksUserNode)
+      maxSizePerAZ: $(tksUserNodeMax)
+      selector:
+        matchLabels:
       machineType: $(tksUserNodeType)
-      replicas: $(tksUserNode)
-      minSize: 0
-      maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50
         type: gp2
-      roleAdditionalPolicies:
-      - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 
 - name: ingress-nginx
   override:
@@ -113,15 +115,3 @@ charts:
   override:
     deployMgmtRbacOnly:
       targetNamespace: $(clusterName)
-
-- name: argo-rollouts
-  override:
-    controller:
-      nodeSelector:
-        taco-lma: enabled
-      replicas: 2
-      image:
-        registry: harbor.taco-cat.xyz
-        repository: tks/argo-rollouts
-        tag: v1.4.1
-

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -10,9 +10,8 @@ global:
   clusterRegion: CHANGEME
   cloudAccountID: CHANGEME
 
-  tksCpNode: CHNAGEME
-  tksCpNodeMax: CHANGEME
-  tksCpNodeType: CHANGEME
+  tksCpNode: 3
+  tksCpNodeType: m5a.2xlarge
   tksInfraNode: CHNAGEME
   tksInfraNodeMax: CHANGEME
   tksInfraNodeType: CHANGEME
@@ -49,10 +48,12 @@ charts:
             protocol: tcp
             fromPort: 5473
             toPort: 5473
-      bastion.enabled: false
-      baseOS: ubuntu-22.04
+      bastion:
+        enabled: false
+      baseOS: ubuntu-20.04
     kubeadmControlPlane:
       replicas: $(tksCpNode)
+      controlPlaneMachineType: $(tksCpNodeType)
     machinePool:
     - name: taco
       machineType: $(tksInfraNodeType)
@@ -68,16 +69,17 @@ charts:
         taco-ingress-gateway: enabled
       roleAdditionalPolicies:
       - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+    machineDeployment:
     - name: normal
+      numberOfAZ: 3 # ap-northeast-2
+      minSizePerAZ: $(tksUserNode)
+      maxSizePerAZ: $(tksUserNodeMax)
+      selector:
+        matchLabels:
       machineType: $(tksUserNodeType)
-      replicas: $(tksUserNode)
-      minSize: 0
-      maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50
         type: gp2
-      roleAdditionalPolicies:
-      - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 
 - name: ingress-nginx
   override:


### PR DESCRIPTION
프로덕션 환경 적용을 위한 aws*-reference 사이트 수정입니다.
- 컨트롤 플레인 형상은 고정: 3 nodes x t3.large
- OS: Ubuntu 20.04 (22.04는 CAPA에서 AMI 이미지 미제공)
- 사용자 워커 노드는 MachineDeployment로 변경
  - 총 노드 수는 콘솔에서 입력 받은 개수 * AZ 개수로 구성: 각 AZ마다 MachineDeployment 배포
  - AZ개수는 ap-northeast-2 기준 3개로 소정
  - 현재는 cluster-autoscaler를 위한 min(tksUserNode), max(tksUserNodeMax) 개수가 기본 배포하는 개수(tksUserNode)와 동일하기 때문에 자동 확장 되지는 않습니다.