### PR TITLE
aws*-reference: use m6i.2xlarge for control plane node

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -11,7 +11,7 @@ global:
   cloudAccountID: CHANGEME
 
   tksCpNode: 3
-  tksCpNodeType: m5a.2xlarge
+  tksCpNodeType: m6i.2xlarge
   tksInfraNode: CHNAGEME
   tksInfraNodeMax: CHANGEME
   tksInfraNodeType: CHANGEME

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -11,7 +11,7 @@ global:
   cloudAccountID: CHANGEME
 
   tksCpNode: 3
-  tksCpNodeType: m5a.2xlarge
+  tksCpNodeType: m6i.2xlarge
   tksInfraNode: CHNAGEME
   tksInfraNodeMax: CHANGEME
   tksInfraNodeType: CHANGEME


### PR DESCRIPTION
aws*-reference 컨트롤 플레인 노드 타입을 m6i.2xlarge으로 사용합니다. (CA팀 요청 사항)