### PR TITLE
bugfix. set node min value as users data

### DIFF
--- a/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/aws-msa-reference/tks-cluster/site-values.yaml
@@ -58,7 +58,7 @@ charts:
     - name: taco
       machineType: $(tksInfraNodeType)
       replicas: $(tksInfraNode)
-      minSize: 0
+      minSize: $(tksInfraNode)
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200

--- a/aws-reference/tks-cluster/site-values.yaml
+++ b/aws-reference/tks-cluster/site-values.yaml
@@ -58,7 +58,7 @@ charts:
     - name: taco
       machineType: $(tksInfraNodeType)
       replicas: $(tksInfraNode)
-      minSize: 0
+      minSize: $(tksInfraNode)
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200

--- a/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/eks-msa-reference/tks-cluster/site-values.yaml
@@ -44,7 +44,7 @@ charts:
     - name: taco
       machineType: $(tksInfraNodeType)
       replicas: $(tksInfraNode)
-      minSize: 0
+      minSize: $(tksInfraNode)
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
@@ -59,7 +59,7 @@ charts:
     - name: normal
       machineType: $(tksUserNodeType)
       replicas: $(tksUserNode)
-      minSize: 0
+      minSize: $(tksUserNode)
       maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50

--- a/eks-reference/tks-cluster/site-values.yaml
+++ b/eks-reference/tks-cluster/site-values.yaml
@@ -47,7 +47,7 @@ charts:
     - name: taco
       machineType: $(tksInfraNodeType)
       replicas: $(tksInfraNode)
-      minSize: 0
+      minSize: $(tksInfraNode)
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
@@ -62,7 +62,7 @@ charts:
     - name: normal
       machineType: $(tksUserNodeType)
       replicas: $(tksUserNode)
-      minSize: 0
+      minSize: $(tksUserNode)
       maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50


### PR DESCRIPTION
사용자가 입력한 값을 cluster min 값으로 사용한다.

eks
 . min, max 모두 동일 값 사용.

aws
 . min, max 모두 동일 값 사용. ( 단 이는 az 당 min, max 값으로 실제 개수는 * az개수 가 됨 )
