### PR TITLE
SKB Grafana 상에서 Network 정보 수집 에러 fix & Keycloak 수작업 내용 반영

### DIFF
--- a/byoh-ssu-reference/lma/site-values.yaml
+++ b/byoh-ssu-reference/lma/site-values.yaml
@@ -102,8 +102,7 @@ charts:
         repeat_interval: 1h
 
 - name: prometheus-node-exporter
-  override:
-    hostNetwork: false
+
 
 - name: kube-state-metrics
   override:
@@ -117,7 +116,6 @@ charts:
 - name: prometheus-process-exporter
   override:
     conf.processes: dockerd,kubelet,kube-proxy,ntpd,node
-    pod.hostNetwork: false
 
 - name: grafana
   override:

--- a/byoh-ssu-reference/tks-admin-tools/site-values.yaml
+++ b/byoh-ssu-reference/tks-admin-tools/site-values.yaml
@@ -38,6 +38,13 @@ charts:
         virtual-server.f5.com/partition: TO_BE_FIXED
       externalDatabase.host: $(dbHost)
       externalDatabase.password: $(commonPassword)
+      extraEnvVars:
+      - name: QUARKUS_TRANSACTION_MANAGER_ENABLE_RECOVERY
+        value: "true"
+      - name: KC_HOSTNAME_ADMIN_URL
+        value: "https://tks-console-adm.skbroadband.com/auth"
+      - name: KC_HOSTNAME_URL
+        value: "https://tks-console-adm.skbroadband.com/auth"
 
   - name: tks-apis
     override:

--- a/byoh-stage-reference/lma/site-values.yaml
+++ b/byoh-stage-reference/lma/site-values.yaml
@@ -102,8 +102,6 @@ charts:
         repeat_interval: 1h
 
 - name: prometheus-node-exporter
-  override:
-    hostNetwork: false
 
 - name: kube-state-metrics
   override:
@@ -117,7 +115,6 @@ charts:
 - name: prometheus-process-exporter
   override:
     conf.processes: dockerd,kubelet,kube-proxy,ntpd,node
-    pod.hostNetwork: false
 
 - name: grafana
   override:

--- a/byoh-stage-reference/tks-admin-tools/site-values.yaml
+++ b/byoh-stage-reference/tks-admin-tools/site-values.yaml
@@ -38,6 +38,13 @@ charts:
         virtual-server.f5.com/partition: TO_BE_FIXED
       externalDatabase.host: $(dbHost)
       externalDatabase.password: $(commonPassword)
+      extraEnvVars:
+      - name: QUARKUS_TRANSACTION_MANAGER_ENABLE_RECOVERY
+        value: "true"
+      - name: KC_HOSTNAME_ADMIN_URL
+        value: "https://tks-console-stg.skbroadband.com/auth"
+      - name: KC_HOSTNAME_URL
+        value: "https://tks-console-stg.skbroadband.com/auth"
 
   - name: tks-apis
     override:

--- a/byoh-suy-reference/lma/site-values.yaml
+++ b/byoh-suy-reference/lma/site-values.yaml
@@ -102,8 +102,6 @@ charts:
         repeat_interval: 1h
 
 - name: prometheus-node-exporter
-  override:
-    hostNetwork: false
 
 - name: kube-state-metrics
   override:
@@ -117,7 +115,6 @@ charts:
 - name: prometheus-process-exporter
   override:
     conf.processes: dockerd,kubelet,kube-proxy,ntpd,node
-    pod.hostNetwork: false
 
 - name: grafana
   override:


### PR DESCRIPTION
수정내역:
1. Node exporter가 hostnetwork으로 실행될 수 있도록 수정하였습니다.
2. x-forwarded-for 설정이 안된 proxy 뒤에서 동작하는 경우에 대해 정상 동작할 수 있도록 수정하였습니다.