### PR TITLE
lma: seperate clusterName and clusterDomain explicitly

### DIFF
--- a/aws-msa-reference/lma/site-values.yaml
+++ b/aws-msa-reference/lma/site-values.yaml
@@ -7,6 +7,7 @@ global:
   nodeSelector:
     taco-lma: enabled
   clusterName: cluster.local
+  clusterDomain: cluster.local
   storageClassName: taco-storage
   repository: https://openinfradev.github.io/helm-repo/
   serviceScrapeInterval: 30s
@@ -18,7 +19,7 @@ global:
   lokiPort: 80
   lokiuserHost: loki-user-loki-distributed-gateway
   lokiuserPort: 80
-  s3Service: "minio.lma.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
+  s3Service: "minio.taco-system.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
 
   lmaNameSpace: taco-system
 
@@ -222,7 +223,7 @@ charts:
         port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
     conf.default.hosts:
-    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+    - "https://eck-elasticsearch-es-http.$(lmaNameSpace).svc.$(clusterDomain):9200"
 
 - name: minio
   override:
@@ -255,7 +256,7 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
-    # clusterDomain: $(clusterName)
+    # clusterDomain: $(clusterDomain)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     query.service.type: LoadBalancer
@@ -324,7 +325,7 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)
@@ -358,7 +359,7 @@ charts:
 - name: loki-user
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)

--- a/aws-reference/lma/site-values.yaml
+++ b/aws-reference/lma/site-values.yaml
@@ -7,6 +7,7 @@ global:
   nodeSelector:
     taco-lma: enabled
   clusterName: cluster.local
+  clusterDomain: cluster.local
   storageClassName: taco-storage
   repository: https://openinfradev.github.io/helm-repo/
   serviceScrapeInterval: 30s
@@ -18,7 +19,7 @@ global:
   lokiPort: 80
   lokiuserHost: loki-user-loki-distributed-gateway
   lokiuserPort: 80
-  s3Service: "minio.lma.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
+  s3Service: "minio.taco-system.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
 
   lmaNameSpace: taco-system
 
@@ -222,7 +223,7 @@ charts:
         port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
     conf.default.hosts:
-    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+    - "https://eck-elasticsearch-es-http.$(lmaNameSpace).svc.$(clusterDomain):9200"
 
 - name: minio
   override:
@@ -254,7 +255,7 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
-    # clusterDomain: $(clusterName)
+    # clusterDomain: $(clusterDomain)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     query.service.type: LoadBalancer
@@ -323,7 +324,7 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)
@@ -357,7 +358,7 @@ charts:
 - name: loki-user
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)

--- a/byoh-reference/lma/site-values.yaml
+++ b/byoh-reference/lma/site-values.yaml
@@ -7,6 +7,7 @@ global:
   nodeSelector:
     taco-lma: enabled
   clusterName: cluster.local
+  clusterDomain: cluster.local
   storageClassName: taco-storage
   repository: https://openinfradev.github.io/helm-repo/
   serviceScrapeInterval: 30s
@@ -18,7 +19,7 @@ global:
   lokiPort: 80
   lokiuserHost: loki-user-loki-distributed-gateway
   lokiuserPort: 80
-  s3Service: "minio.lma.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
+  s3Service: "minio.taco-system.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
 
   lmaNameSpace: taco-system
 
@@ -225,7 +226,7 @@ charts:
         port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
     conf.default.hosts:
-    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+    - "https://eck-elasticsearch-es-http.$(lmaNameSpace).svc.$(clusterDomain):9200"
 
 - name: minio
   override:
@@ -260,7 +261,7 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
-    # clusterDomain: $(clusterName)
+    # clusterDomain: $(clusterDomain)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     query.service.type: ClusterIP
@@ -333,7 +334,7 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service:
       type: NodePort
       nodePort: 30002

--- a/eks-msa-reference/lma/site-values.yaml
+++ b/eks-msa-reference/lma/site-values.yaml
@@ -7,6 +7,7 @@ global:
   nodeSelector:
     taco-lma: enabled
   clusterName: cluster.local
+  clusterDomain: cluster.local
   storageClassName: taco-storage
   repository: https://openinfradev.github.io/helm-repo/
   serviceScrapeInterval: 30s
@@ -18,7 +19,7 @@ global:
   lokiPort: 80
   lokiuserHost: loki-user-loki-distributed-gateway
   lokiuserPort: 80
-  s3Service: "minio.lma.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
+  s3Service: "minio.taco-system.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
 
   lmaNameSpace: taco-system
 
@@ -200,7 +201,6 @@ charts:
     prometheusRules.istio.aggregation.enabled: false
     prometheusRules.istio.optimization.enabled: false
     grafanaDatasource.prometheus.url: $(grafanaDatasourceMetric)
-    # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
     grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 
 - name: prometheus-adapter
@@ -223,7 +223,7 @@ charts:
         port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
     conf.default.hosts:
-    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+    - "https://eck-elasticsearch-es-http.$(lmaNameSpace).svc.$(clusterDomain):9200"
 
 - name: minio
   override:
@@ -256,7 +256,7 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
-    # clusterDomain: $(clusterName)
+    # clusterDomain: $(clusterDomain)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     query.service.type: LoadBalancer
@@ -325,7 +325,7 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)
@@ -359,7 +359,7 @@ charts:
 - name: loki-user
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)

--- a/eks-reference/lma/site-values.yaml
+++ b/eks-reference/lma/site-values.yaml
@@ -7,6 +7,7 @@ global:
   nodeSelector:
     taco-lma: enabled
   clusterName: cluster.local
+  clusterDomain: cluster.local
   storageClassName: taco-storage
   repository: https://openinfradev.github.io/helm-repo/
   serviceScrapeInterval: 30s
@@ -18,7 +19,7 @@ global:
   lokiPort: 80
   lokiuserHost: loki-user-loki-distributed-gateway
   lokiuserPort: 80
-  s3Service: "minio.lma.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
+  s3Service: "minio.taco-system.svc:9000" # depends on $lmaNameSpace (ex. minio.taco-system.svc)
 
   lmaNameSpace: taco-system
 
@@ -223,7 +224,7 @@ charts:
         port: $(lokiPort)
         target_file: "/tmp/kubernetes-event.log"
     conf.default.hosts:
-    - "https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200"
+    - "https://eck-elasticsearch-es-http.$(lmaNameSpace).svc.$(clusterDomain):9200"
 
 - name: minio
   override:
@@ -256,7 +257,7 @@ charts:
   override:
     global.storageClass: $(storageClassName)
     # temporarily add annotation because a cluster is using not cluster-name but 'cluster.local'
-    # clusterDomain: $(clusterName)
+    # clusterDomain: $(clusterDomain)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
     query.service.type: LoadBalancer
@@ -325,7 +326,7 @@ charts:
 - name: loki
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)
@@ -359,7 +360,7 @@ charts:
 - name: loki-user
   override:
     global.dnsService: kube-dns
-    # global.clusterDomain: $(clusterName) # annotate cluste because the cluster name is still cluster.local regardless cluster
+    # global.clusterDomain: $(clusterDomain) # annotate cluste because the cluster name is still cluster.local regardless cluster
     gateway.service.type: LoadBalancer
     gateway.service.annotations: $(awsNlbAnnotation)
     ingester.persistence.storageClass: $(storageClassName)


### PR DESCRIPTION
clusterName으로 url과 클러스터 표기를 병행했던것을 명확하게 분리
- 현재 클러스터명을 url에 넣지 못하는 이슈가 있어, 이에대한 회피를 통해 잠재적인 에러들을 만들고 있었음